### PR TITLE
chore: scaffold monorepo foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.DS_Store
+pnpm-lock.yaml
+.next
+out
+coverage
+/dist
+/apps/**/.next
+/apps/**/dist
+/apps/**/build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# TrendPot Monorepo
+
+This repository is now bootstrapped with a Turborepo workspace that hosts the customer-facing web application, NestJS API, background worker, and shared packages. The long-form product and architecture brief that follows remains unchanged for reference.
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The `pnpm dev` script runs all dev servers declared in the workspace via Turbo. Each package can also be developed individually (see `apps/` and `packages/`).
+
+---
+
 # TrendPot
 PWA that ranks top TikTok challenge videos (consenting creators) and powers fan donations via M-Pesa. Stack: Next.js (PWA) • NestJS • MongoDB Atlas • Redis • BullMQ.
 

--- a/apps/api/.eslintrc.json
+++ b/apps/api/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "env": {
+    "node": true
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "api",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/main.ts",
+    "start": "node dist/main.js",
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "@fastify/cors": "9.0.1",
+    "@nestjs/common": "10.3.7",
+    "@nestjs/core": "10.3.7",
+    "@nestjs/platform-fastify": "10.3.7",
+    "reflect-metadata": "0.1.14",
+    "rxjs": "7.8.1",
+    "@trendpot/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "7.5.0",
+    "@typescript-eslint/parser": "7.5.0",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "prettier": "3.2.5",
+    "tsx": "4.7.2",
+    "typescript": "5.4.5",
+    "@types/node": "20.12.7"
+  }
+}

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from "@nestjs/common";
+import { AppService } from "./app.service";
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get("/health")
+  getHealth() {
+    return { status: "ok", uptime: process.uptime(), service: "trendpot-api" };
+  }
+
+  @Get("/v1/challenges")
+  getChallenges() {
+    return this.appService.getFeaturedChallenges();
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+
+@Module({
+  imports: [],
+  controllers: [AppController],
+  providers: [AppService]
+})
+export class AppModule {}

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from "@nestjs/common";
+import type { ChallengeSummary } from "@trendpot/types";
+
+const demoChallenges: ChallengeSummary[] = [
+  {
+    id: "sunset-sprint",
+    title: "Sunset Sprint",
+    tagline: "Capture golden hour transitions in 30 seconds",
+    raised: 4200,
+    currency: "KES",
+    goal: 10000
+  },
+  {
+    id: "duet-drive",
+    title: "Duet Drive",
+    tagline: "Weekly duet challenge uplifting Kenyan dancers",
+    raised: 1850,
+    currency: "KES",
+    goal: 5000
+  }
+];
+
+@Injectable()
+export class AppService {
+  getFeaturedChallenges(): ChallengeSummary[] {
+    return demoChallenges;
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+import { Logger } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { FastifyAdapter, NestFastifyApplication } from "@nestjs/platform-fastify";
+import cors from "@fastify/cors";
+import { AppModule } from "./app.module";
+
+const bootstrap = async () => {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter({ logger: false })
+  );
+
+  await app.register(cors, {
+    origin: true,
+    credentials: true
+  });
+
+  const port = Number(process.env.PORT ?? 4000);
+
+  await app.listen({ port, host: "0.0.0.0" });
+  Logger.log(`🚀 API running on http://localhost:${port}`, "Bootstrap");
+};
+
+void bootstrap();

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "removeComments": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts", "node_modules"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../packages/config/tsconfig/node.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {}
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+    serverActions: true
+  }
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --check ."
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@trendpot/ui": "workspace:*",
+    "@trendpot/utils": "workspace:*",
+    "@trendpot/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.35",
+    "prettier": "3.2.5",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+a {
+  text-decoration: none;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,31 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "TrendPot",
+  description: "Discover TikTok challenges and support creators."
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="bg-slate-950 text-slate-100">
+      <body className="min-h-screen font-sans antialiased">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 py-16">
+          <header>
+            <p className="text-sm uppercase tracking-wide text-slate-400">TrendPot</p>
+            <h1 className="mt-2 text-3xl font-semibold">Creator growth analytics & giving</h1>
+            <p className="mt-2 max-w-2xl text-base text-slate-300">
+              Track viral momentum, rally donations, and celebrate community wins with
+              a progressive web experience built for short-form storytellers.
+            </p>
+          </header>
+          <main>{children}</main>
+          <footer className="border-t border-slate-800 pt-6 text-xs text-slate-500">
+            <p>&copy; {new Date().getFullYear()} TrendPot. All rights reserved.</p>
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { Button } from "@trendpot/ui";
+
+const demoChallenges = [
+  {
+    slug: "sunset-sprint",
+    title: "Sunset Sprint",
+    description: "Creators race to catch golden hour transitions in 30 seconds.",
+    raised: 4200,
+    goal: 10000
+  },
+  {
+    slug: "duet-drive",
+    title: "Duet Drive",
+    description: "A weekly duet challenge supporting emerging Kenyan dancers.",
+    raised: 1850,
+    goal: 5000
+  }
+];
+
+export default function HomePage() {
+  return (
+    <div className="space-y-12">
+      <section className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/40">
+        <h2 className="text-2xl font-semibold text-white">Campaign Pulse</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Monitor performance signals from TikTok to understand which challenges are
+          gaining traction across the community.
+        </p>
+        <dl className="mt-6 grid gap-6 sm:grid-cols-3">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Active Challenges</dt>
+            <dd className="mt-2 text-3xl font-semibold text-white">12</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Creator Submissions</dt>
+            <dd className="mt-2 text-3xl font-semibold text-white">384</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Donations Processed</dt>
+            <dd className="mt-2 text-3xl font-semibold text-white">KES 1.8M</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-white">Featured challenges</h2>
+            <p className="text-sm text-slate-300">Preview a curated stream of creator-led campaigns.</p>
+          </div>
+          <Link className="text-sm font-medium text-emerald-400 hover:text-emerald-300" href="/challenges">
+            View all
+          </Link>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <article className="rounded-3xl border border-emerald-500/50 bg-emerald-500/10 p-6">
+            <header className="flex flex-col gap-2">
+              <h3 className="text-lg font-semibold text-emerald-300">Launch your first campaign</h3>
+              <p className="text-sm text-emerald-200/80">Kick off a creator challenge with automated storytelling prompts, metrics, and donation tooling.</p>
+            </header>
+            <Button className="mt-6 w-fit" variant="primary">Create challenge</Button>
+          </article>
+          {demoChallenges.map((challenge) => {
+            const completion = Math.min(100, Math.round((challenge.raised / challenge.goal) * 100));
+            return (
+              <article key={challenge.slug} className="rounded-3xl border border-slate-800 bg-slate-900/80 p-6">
+                <header>
+                  <h3 className="text-lg font-semibold text-white">{challenge.title}</h3>
+                  <p className="mt-1 text-sm text-slate-300">{challenge.description}</p>
+                </header>
+                <div className="mt-4 space-y-2">
+                  <div className="h-2 overflow-hidden rounded-full bg-slate-800">
+                    <div className="h-full rounded-full bg-emerald-500" style={{ width: `${completion}%` }} />
+                  </div>
+                  <p className="text-xs text-slate-400">
+                    Raised KES {challenge.raised.toLocaleString()} of KES {challenge.goal.toLocaleString()} goal
+                  </p>
+                </div>
+                <Link
+                  className="mt-4 inline-flex items-center text-sm font-medium text-emerald-400 hover:text-emerald-300"
+                  href={`/c/${challenge.slug}`}
+                >
+                  View insights
+                </Link>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "../../packages/ui/src/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../packages/config/tsconfig/next.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@trendpot/ui": ["../../packages/ui/src"],
+      "@trendpot/utils": ["../../packages/utils/src"],
+      "@trendpot/types": ["../../packages/types/src"]
+    }
+  }
+}

--- a/apps/worker/.eslintrc.json
+++ b/apps/worker/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "env": {
+    "node": true
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "worker",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "bullmq": "4.11.4",
+    "ioredis": "5.4.1",
+    "@trendpot/types": "workspace:*",
+    "@trendpot/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "7.5.0",
+    "@typescript-eslint/parser": "7.5.0",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "prettier": "3.2.5",
+    "tsx": "4.7.2",
+    "typescript": "5.4.5",
+    "@types/node": "20.12.7"
+  }
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,37 @@
+import { Queue, Worker } from "bullmq";
+import IORedis from "ioredis";
+import { challengeLeaderboardSchema } from "@trendpot/types";
+import { withRetries } from "@trendpot/utils";
+
+const connection = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6379");
+
+export const leaderboardQueue = new Queue("leaderboard", { connection });
+
+const jobHandler = async () => {
+  const payload = challengeLeaderboardSchema.parse({
+    generatedAt: new Date().toISOString(),
+    leaders: [
+      { id: "sunset-sprint", title: "Sunset Sprint", score: 98 },
+      { id: "duet-drive", title: "Duet Drive", score: 83 },
+      { id: "nightwave", title: "Nightwave", score: 75 }
+    ]
+  });
+
+  return payload;
+};
+
+const worker = new Worker(
+  leaderboardQueue.name,
+  async () => withRetries(jobHandler, { retries: 2 }),
+  { connection }
+);
+
+worker.on("completed", (job, result) => {
+  console.log(`[leaderboard] job ${job.id} completed`, result);
+});
+
+worker.on("failed", (job, err) => {
+  console.error(`[leaderboard] job ${job?.id} failed`, err);
+});
+
+console.log("📊 Worker ready to process leaderboard jobs");

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../packages/config/tsconfig/node.json",
+  "compilerOptions": {
+    "baseUrl": "src",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+Terraform modules and environment configurations will live here. The initial application scaffolding focuses on application code, but this directory documents the intended location for infrastructure-as-code assets.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "trendpot",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "format": "turbo run format --parallel"
+  },
+  "devDependencies": {
+    "turbo": "^1.11.3"
+  }
+}

--- a/packages/config/tsconfig/base.json
+++ b/packages/config/tsconfig/base.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Base",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/config/tsconfig/next.json
+++ b/packages/config/tsconfig/next.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "display": "Next.js",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": true,
+    "noEmit": true,
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/config/tsconfig/node.json
+++ b/packages/config/tsconfig/node.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "display": "Node",
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "sourceMap": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/types/.eslintrc.json
+++ b/packages/types/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "env": {
+    "es2022": true
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@trendpot/types",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "lint": "eslint \"src/**/*.ts\"",
+    "format": "prettier --check \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "zod": "3.23.4"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "7.5.0",
+    "@typescript-eslint/parser": "7.5.0",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "prettier": "3.2.5",
+    "typescript": "5.4.5"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const challengeSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  tagline: z.string(),
+  raised: z.number().nonnegative(),
+  goal: z.number().positive(),
+  currency: z.string().length(3)
+});
+
+export type ChallengeSummary = z.infer<typeof challengeSummarySchema>;
+
+export const challengeLeaderboardSchema = z.object({
+  generatedAt: z.string(),
+  leaders: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      score: z.number().min(0).max(100)
+    })
+  )
+});
+
+export type ChallengeLeaderboard = z.infer<typeof challengeLeaderboardSchema>;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../config/tsconfig/base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/ui/.eslintrc.json
+++ b/packages/ui/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@trendpot/ui",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "clsx": "2.1.0",
+    "react": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.21",
+    "@typescript-eslint/eslint-plugin": "7.5.0",
+    "@typescript-eslint/parser": "7.5.0",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "prettier": "3.2.5",
+    "typescript": "5.4.5"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,20 @@
+import { clsx } from "clsx";
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary";
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "primary", ...props }, ref) => {
+    const base = "inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-medium transition";
+    const variants: Record<NonNullable<ButtonProps["variant"]>, string> = {
+      primary: "bg-emerald-500 text-slate-950 hover:bg-emerald-400",
+      secondary: "border border-slate-700 bg-slate-900 text-slate-100 hover:border-slate-500"
+    };
+
+    return <button ref={ref} className={clsx(base, variants[variant], className)} {...props} />;
+  }
+);
+
+Button.displayName = "Button";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../config/tsconfig/base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/utils/.eslintrc.json
+++ b/packages/utils/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
+  ],
+  "env": {
+    "es2022": true
+  },
+  "ignorePatterns": ["dist", "node_modules"]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@trendpot/utils",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "lint": "eslint \"src/**/*.ts\"",
+    "format": "prettier --check \"src/**/*.ts\""
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "7.5.0",
+    "@typescript-eslint/parser": "7.5.0",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "prettier": "3.2.5",
+    "typescript": "5.4.5"
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,23 @@
+export interface RetryOptions {
+  retries?: number;
+  delayMs?: number;
+}
+
+export const withRetries = async <T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> => {
+  const { retries = 0, delayMs = 250 } = options;
+
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= retries) {
+        throw error;
+      }
+
+      attempt += 1;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+};

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../config/tsconfig/base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - apps/*
+  - packages/*
+  - infra/*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": []
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.json"],
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**", ".next/**"]
+    },
+    "dev": {
+      "cache": false
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["lint"],
+      "outputs": []
+    },
+    "format": {
+      "cache": false,
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- set up a pnpm-based Turborepo workspace with shared TypeScript configuration and linting defaults
- scaffold the Next.js PWA shell with Tailwind styling and shared UI integration
- create NestJS API, BullMQ worker, and shared `types`, `ui`, and `utils` packages with starter logic

## Testing
- `pnpm lint` *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01e337770832eaaad91cc2887d1cb