### PR TITLE
feat: hydrate featured challenges from API

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Query } from "@nestjs/common";
+import type { ListChallengesParams } from "@trendpot/types";
 import { AppService } from "./app.service";
 
 @Controller()
@@ -11,7 +12,20 @@ export class AppController {
   }
 
   @Get("/v1/challenges")
-  getChallenges() {
-    return this.appService.getFeaturedChallenges();
+  getChallenges(@Query("status") status?: string, @Query("limit") limit?: string) {
+    const params: ListChallengesParams = {};
+
+    if (typeof status === "string" && status.length > 0) {
+      params.status = status;
+    }
+
+    if (typeof limit === "string") {
+      const parsedLimit = Number.parseInt(limit, 10);
+      if (!Number.isNaN(parsedLimit)) {
+        params.limit = parsedLimit;
+      }
+    }
+
+    return this.appService.getFeaturedChallenges(params);
   }
 }

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@nestjs/common";
-import type { ChallengeSummary } from "@trendpot/types";
+import type { ChallengeSummary, ListChallengesParams } from "@trendpot/types";
 
 const demoChallenges: ChallengeSummary[] = [
   {
@@ -22,7 +22,25 @@ const demoChallenges: ChallengeSummary[] = [
 
 @Injectable()
 export class AppService {
-  getFeaturedChallenges(): ChallengeSummary[] {
+  getFeaturedChallenges(params: ListChallengesParams = {}): ChallengeSummary[] {
+    const limit = sanitizeLimit(params.limit);
+
+    if (typeof limit === "number") {
+      return demoChallenges.slice(0, limit);
+    }
+
     return demoChallenges;
   }
 }
+
+const sanitizeLimit = (limit: ListChallengesParams["limit"]): number | undefined => {
+  if (typeof limit !== "number") {
+    return undefined;
+  }
+
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return undefined;
+  }
+
+  return Math.floor(limit);
+};

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --check ."
   },
   "dependencies": {
+    "@tanstack/react-query": "5.37.1",
     "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { ReactNode } from "react";
+import { Providers } from "./providers";
 
 export const metadata: Metadata = {
   title: "TrendPot",
@@ -11,20 +12,22 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className="bg-slate-950 text-slate-100">
       <body className="min-h-screen font-sans antialiased">
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 py-16">
-          <header>
-            <p className="text-sm uppercase tracking-wide text-slate-400">TrendPot</p>
-            <h1 className="mt-2 text-3xl font-semibold">Creator growth analytics & giving</h1>
-            <p className="mt-2 max-w-2xl text-base text-slate-300">
-              Track viral momentum, rally donations, and celebrate community wins with
-              a progressive web experience built for short-form storytellers.
-            </p>
-          </header>
-          <main>{children}</main>
-          <footer className="border-t border-slate-800 pt-6 text-xs text-slate-500">
-            <p>&copy; {new Date().getFullYear()} TrendPot. All rights reserved.</p>
-          </footer>
-        </div>
+        <Providers>
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 py-16">
+            <header>
+              <p className="text-sm uppercase tracking-wide text-slate-400">TrendPot</p>
+              <h1 className="mt-2 text-3xl font-semibold">Creator growth analytics & giving</h1>
+              <p className="mt-2 max-w-2xl text-base text-slate-300">
+                Track viral momentum, rally donations, and celebrate community wins with
+                a progressive web experience built for short-form storytellers.
+              </p>
+            </header>
+            <main>{children}</main>
+            <footer className="border-t border-slate-800 pt-6 text-xs text-slate-500">
+              <p>&copy; {new Date().getFullYear()} TrendPot. All rights reserved.</p>
+            </footer>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,93 +1,14 @@
-import Link from "next/link";
-import { Button } from "@trendpot/ui";
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { HomeContent } from "../components/home/home-content";
+import { featuredChallengesQueryOptions } from "../lib/challenge-queries";
 
-const demoChallenges = [
-  {
-    slug: "sunset-sprint",
-    title: "Sunset Sprint",
-    description: "Creators race to catch golden hour transitions in 30 seconds.",
-    raised: 4200,
-    goal: 10000
-  },
-  {
-    slug: "duet-drive",
-    title: "Duet Drive",
-    description: "A weekly duet challenge supporting emerging Kenyan dancers.",
-    raised: 1850,
-    goal: 5000
-  }
-];
+export default async function HomePage() {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery(featuredChallengesQueryOptions());
 
-export default function HomePage() {
   return (
-    <div className="space-y-12">
-      <section className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/40">
-        <h2 className="text-2xl font-semibold text-white">Campaign Pulse</h2>
-        <p className="mt-2 text-sm text-slate-300">
-          Monitor performance signals from TikTok to understand which challenges are
-          gaining traction across the community.
-        </p>
-        <dl className="mt-6 grid gap-6 sm:grid-cols-3">
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
-            <dt className="text-xs uppercase tracking-wide text-slate-400">Active Challenges</dt>
-            <dd className="mt-2 text-3xl font-semibold text-white">12</dd>
-          </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
-            <dt className="text-xs uppercase tracking-wide text-slate-400">Creator Submissions</dt>
-            <dd className="mt-2 text-3xl font-semibold text-white">384</dd>
-          </div>
-          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
-            <dt className="text-xs uppercase tracking-wide text-slate-400">Donations Processed</dt>
-            <dd className="mt-2 text-3xl font-semibold text-white">KES 1.8M</dd>
-          </div>
-        </dl>
-      </section>
-
-      <section className="space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h2 className="text-2xl font-semibold text-white">Featured challenges</h2>
-            <p className="text-sm text-slate-300">Preview a curated stream of creator-led campaigns.</p>
-          </div>
-          <Link className="text-sm font-medium text-emerald-400 hover:text-emerald-300" href="/challenges">
-            View all
-          </Link>
-        </div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <article className="rounded-3xl border border-emerald-500/50 bg-emerald-500/10 p-6">
-            <header className="flex flex-col gap-2">
-              <h3 className="text-lg font-semibold text-emerald-300">Launch your first campaign</h3>
-              <p className="text-sm text-emerald-200/80">Kick off a creator challenge with automated storytelling prompts, metrics, and donation tooling.</p>
-            </header>
-            <Button className="mt-6 w-fit" variant="primary">Create challenge</Button>
-          </article>
-          {demoChallenges.map((challenge) => {
-            const completion = Math.min(100, Math.round((challenge.raised / challenge.goal) * 100));
-            return (
-              <article key={challenge.slug} className="rounded-3xl border border-slate-800 bg-slate-900/80 p-6">
-                <header>
-                  <h3 className="text-lg font-semibold text-white">{challenge.title}</h3>
-                  <p className="mt-1 text-sm text-slate-300">{challenge.description}</p>
-                </header>
-                <div className="mt-4 space-y-2">
-                  <div className="h-2 overflow-hidden rounded-full bg-slate-800">
-                    <div className="h-full rounded-full bg-emerald-500" style={{ width: `${completion}%` }} />
-                  </div>
-                  <p className="text-xs text-slate-400">
-                    Raised KES {challenge.raised.toLocaleString()} of KES {challenge.goal.toLocaleString()} goal
-                  </p>
-                </div>
-                <Link
-                  className="mt-4 inline-flex items-center text-sm font-medium text-emerald-400 hover:text-emerald-300"
-                  href={`/c/${challenge.slug}`}
-                >
-                  View insights
-                </Link>
-              </article>
-            );
-          })}
-        </div>
-      </section>
-    </div>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <HomeContent />
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            staleTime: 1000 * 30,
+            retry: 1
+          }
+        }
+      })
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apps/web/src/components/home/home-content.tsx
+++ b/apps/web/src/components/home/home-content.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@trendpot/ui";
+import type { ChallengeSummary } from "@trendpot/types";
+import { FEATURED_CHALLENGE_LIMIT, featuredChallengesQueryOptions } from "../../lib/challenge-queries";
+
+const currencyFormatter = new Intl.NumberFormat("en-KE", {
+  style: "currency",
+  currency: "KES",
+  maximumFractionDigits: 0
+});
+
+const formatAmount = (amount: number, currency: string) => {
+  try {
+    return new Intl.NumberFormat("en-KE", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0
+    }).format(amount);
+  } catch (error) {
+    return currencyFormatter.format(amount);
+  }
+};
+
+const challengeSkeletons = Array.from({ length: FEATURED_CHALLENGE_LIMIT }, (_, index) => index);
+
+export function HomeContent() {
+  const { data, isPending, isError, error, refetch, isRefetching } = useQuery(featuredChallengesQueryOptions());
+  const challenges = data ?? [];
+
+  return (
+    <div className="space-y-12">
+      <section className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-xl shadow-slate-950/40">
+        <h2 className="text-2xl font-semibold text-white">Campaign Pulse</h2>
+        <p className="mt-2 text-sm text-slate-300">
+          Monitor performance signals from TikTok to understand which challenges are gaining traction across the community.
+        </p>
+        <dl className="mt-6 grid gap-6 sm:grid-cols-3">
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Active Challenges</dt>
+            <dd className="mt-2 text-3xl font-semibold text-white">12</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Creator Submissions</dt>
+            <dd className="mt-2 text-3xl font-semibold text-white">384</dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800/70 bg-slate-900/80 p-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-400">Donations Processed</dt>
+            <dd className="mt-2 text-3xl font-semibold text-white">KES 1.8M</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-semibold text-white">Featured challenges</h2>
+            <p className="text-sm text-slate-300">Preview a curated stream of creator-led campaigns.</p>
+          </div>
+          <Link className="text-sm font-medium text-emerald-400 hover:text-emerald-300" href="/challenges">
+            View all
+          </Link>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <article className="rounded-3xl border border-emerald-500/50 bg-emerald-500/10 p-6">
+            <header className="flex flex-col gap-2">
+              <h3 className="text-lg font-semibold text-emerald-300">Launch your first campaign</h3>
+              <p className="text-sm text-emerald-200/80">
+                Kick off a creator challenge with automated storytelling prompts, metrics, and donation tooling.
+              </p>
+            </header>
+            <Button className="mt-6 w-fit" variant="primary">
+              Create challenge
+            </Button>
+          </article>
+          {isPending &&
+            challengeSkeletons.map((item) => (
+              <article key={item} className="animate-pulse rounded-3xl border border-slate-800 bg-slate-900/60 p-6">
+                <div className="h-6 w-40 rounded bg-slate-800/80" />
+                <div className="mt-3 h-4 w-full rounded bg-slate-800/70" />
+                <div className="mt-6 h-2 w-full rounded bg-slate-800/70" />
+                <div className="mt-3 h-3 w-2/3 rounded bg-slate-800/70" />
+              </article>
+            ))}
+          {isError && (
+            <article className="rounded-3xl border border-red-500/40 bg-red-500/10 p-6">
+              <header className="space-y-2">
+                <h3 className="text-lg font-semibold text-red-200">We couldn&apos;t load featured challenges</h3>
+                <p className="text-sm text-red-200/80">{error instanceof Error ? error.message : "Unknown error"}</p>
+              </header>
+              <Button className="mt-4" onClick={() => refetch()} disabled={isRefetching} variant="secondary">
+                Try again
+              </Button>
+            </article>
+          )}
+          {!isPending && !isError &&
+            challenges.map((challenge) => <ChallengeCard key={challenge.id} challenge={challenge} />)}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ChallengeCard({ challenge }: { challenge: ChallengeSummary }) {
+  const completion = Math.min(100, Math.round((challenge.raised / challenge.goal) * 100));
+  const raised = formatAmount(challenge.raised, challenge.currency);
+  const goal = formatAmount(challenge.goal, challenge.currency);
+
+  return (
+    <article className="rounded-3xl border border-slate-800 bg-slate-900/80 p-6">
+      <header>
+        <h3 className="text-lg font-semibold text-white">{challenge.title}</h3>
+        <p className="mt-1 text-sm text-slate-300">{challenge.tagline}</p>
+      </header>
+      <div className="mt-4 space-y-2">
+        <div className="h-2 overflow-hidden rounded-full bg-slate-800">
+          <div className="h-full rounded-full bg-emerald-500" style={{ width: `${completion}%` }} />
+        </div>
+        <p className="text-xs text-slate-400">
+          Raised {raised} of {goal} goal
+        </p>
+      </div>
+      <Link className="mt-4 inline-flex items-center text-sm font-medium text-emerald-400 hover:text-emerald-300" href={`/c/${challenge.id}`}>
+        View insights
+      </Link>
+    </article>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,0 +1,6 @@
+import { TrendPotApiClient } from "@trendpot/types";
+
+const fallbackBaseUrl = "http://localhost:4000";
+const resolvedBaseUrl = process.env.NEXT_PUBLIC_API_URL ?? process.env.API_BASE_URL ?? fallbackBaseUrl;
+
+export const apiClient = new TrendPotApiClient({ baseUrl: resolvedBaseUrl });

--- a/apps/web/src/lib/challenge-queries.ts
+++ b/apps/web/src/lib/challenge-queries.ts
@@ -1,0 +1,17 @@
+import type { ChallengeSummary } from "@trendpot/types";
+import { apiClient } from "./api-client";
+
+export const featuredChallengesParams = { status: "live", limit: 6 } as const;
+export const FEATURED_CHALLENGE_LIMIT = featuredChallengesParams.limit;
+
+export const featuredChallengesQueryKey = ["challenges", "featured", featuredChallengesParams] as const;
+
+export const fetchFeaturedChallenges = async (): Promise<ChallengeSummary[]> => {
+  return apiClient.getFeaturedChallenges(featuredChallengesParams);
+};
+
+export const featuredChallengesQueryOptions = () => ({
+  queryKey: featuredChallengesQueryKey,
+  queryFn: fetchFeaturedChallenges,
+  staleTime: 1000 * 30
+});

--- a/packages/types/src/challenges.ts
+++ b/packages/types/src/challenges.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const challengeSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  tagline: z.string(),
+  raised: z.number().nonnegative(),
+  goal: z.number().positive(),
+  currency: z.string().length(3)
+});
+
+export const challengeSummaryListSchema = z.array(challengeSummarySchema);
+
+export type ChallengeSummary = z.infer<typeof challengeSummarySchema>;
+export type ChallengeSummaryList = z.infer<typeof challengeSummaryListSchema>;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,0 +1,76 @@
+import { challengeSummaryListSchema } from "./challenges";
+
+export interface TrendPotApiClientOptions {
+  baseUrl: string;
+  fetchImplementation?: typeof fetch;
+  defaultHeaders?: HeadersInit;
+}
+
+export interface ListChallengesParams {
+  status?: string;
+  limit?: number;
+}
+
+export class TrendPotApiClient {
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly defaultHeaders: HeadersInit;
+
+  constructor(options: TrendPotApiClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.fetchFn = options.fetchImplementation ?? globalThis.fetch?.bind(globalThis);
+
+    if (!this.fetchFn) {
+      throw new Error("A fetch implementation must be provided when global fetch is unavailable.");
+    }
+
+    this.defaultHeaders = options.defaultHeaders ?? { Accept: "application/json" };
+  }
+
+  async getFeaturedChallenges(params: ListChallengesParams = {}) {
+    const url = this.buildUrl("/v1/challenges", params);
+    const response = await this.fetchFn(url.toString(), {
+      headers: this.defaultHeaders,
+      cache: "no-store"
+    });
+
+    if (!response.ok) {
+      const body = await this.safeJson(response);
+      const message = body && typeof body === "object" && "message" in body ? String(body.message) : response.statusText;
+      throw new Error(`Failed to fetch challenges: ${message}`);
+    }
+
+    const payload = await response.json();
+    return challengeSummaryListSchema.parse(payload);
+  }
+
+  private buildUrl(path: string, params: ListChallengesParams) {
+    const url = new URL(path, `${this.baseUrl}/`);
+
+    if (params.status) {
+      url.searchParams.set("status", params.status);
+    }
+
+    if (typeof params.limit === "number" && Number.isFinite(params.limit) && params.limit > 0) {
+      url.searchParams.set("limit", Math.floor(params.limit).toString());
+    }
+
+    return url;
+  }
+
+  private async safeJson(response: Response): Promise<unknown | null> {
+    const contentType = response.headers.get("content-type");
+    if (!contentType || !contentType.includes("application/json")) {
+      return null;
+    }
+
+    try {
+      return await response.json();
+    } catch (error) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn("Failed to parse error response JSON", error);
+      }
+      return null;
+    }
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,25 +1,3 @@
-import { z } from "zod";
-
-export const challengeSummarySchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  tagline: z.string(),
-  raised: z.number().nonnegative(),
-  goal: z.number().positive(),
-  currency: z.string().length(3)
-});
-
-export type ChallengeSummary = z.infer<typeof challengeSummarySchema>;
-
-export const challengeLeaderboardSchema = z.object({
-  generatedAt: z.string(),
-  leaders: z.array(
-    z.object({
-      id: z.string(),
-      title: z.string(),
-      score: z.number().min(0).max(100)
-    })
-  )
-});
-
-export type ChallengeLeaderboard = z.infer<typeof challengeLeaderboardSchema>;
+export * from "./challenges";
+export * from "./leaderboard";
+export * from "./client";

--- a/packages/types/src/leaderboard.ts
+++ b/packages/types/src/leaderboard.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const challengeLeaderboardSchema = z.object({
+  generatedAt: z.string(),
+  leaders: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      score: z.number().min(0).max(100)
+    })
+  )
+});
+
+export type ChallengeLeaderboard = z.infer<typeof challengeLeaderboardSchema>;


### PR DESCRIPTION
## Summary
- add a reusable TrendPot API client and reorganize shared challenge types
- allow the NestJS /v1/challenges route to accept status and limit params before returning trimmed demo data
- hydrate the Next.js home feed via React Query with loading and error states plus a shared provider

## Testing
- `pnpm install` *(fails: registry blocked in execution environment)*
- `pnpm --filter web lint` *(fails: registry blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d021a81e84832ebd91758e4eb892d4