### PR TITLE
chore: add node-based test harnesses

### DIFF
--- a/DEVELOPMENT_TRACKER.md
+++ b/DEVELOPMENT_TRACKER.md
@@ -116,7 +116,7 @@
 - ☑ **Author seed scripts for Mongo fixtures (challenges, sample users, submissions) and document runbooks.** _(Owner: Backend)_
   - Notes: 2024-06-06 – AI – Added Mongo seed script and seeding runbook.
 - ☐ **Establish unit/integration test harnesses across apps (`web`, `api`, `worker`) with CI pipelines wired.** _(Owner: DX)_
-  - Notes:
+  - Notes: 2025-09-25 – AI – Added Node test harnesses for web/api/worker with representative coverage and scripts.
 - ☐ **Implement structured logging (request IDs, correlation IDs) and baseline error envelopes across API + worker.** _(Owner: Platform)_
   - Notes:
 - ☐ **Capture responsive desktop/mobile design references for baseline pages (`/`, `/challenges`, `/c/[slug]`).** _(Owner: Design)_

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --check \"src/**/*.{ts,tsx}\"",
-    "seed": "tsx scripts/seed.ts"
+    "seed": "tsx scripts/seed.ts",
+    "test": "NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src"
   },
   "dependencies": {
     "@fastify/cors": "9.0.1",

--- a/apps/api/src/app.service.test.ts
+++ b/apps/api/src/app.service.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ChallengeSummary } from "@trendpot/types";
+import { AppService } from "./app.service";
+import { ChallengeEntity } from "./models/challenge.schema";
+
+type ChallengeDocumentLike = ChallengeEntity & { createdAt: Date; updatedAt: Date };
+
+interface QueryState {
+  limitArg?: number;
+  sortArg?: Record<string, number>;
+  execResult: ChallengeDocumentLike[];
+}
+
+// createQueryStub emulates the chainable query builder that Mongoose exposes so
+// we can verify how the service configures find operations without a real
+// database behind the scenes.
+const createQueryStub = () => {
+  const state: QueryState = {
+    execResult: []
+  };
+
+  const query = {
+    sort(sort: Record<string, number>) {
+      state.sortArg = sort;
+      return query;
+    },
+    lean() {
+      return query;
+    },
+    limit(value: number) {
+      state.limitArg = value;
+      return query;
+    },
+    async exec() {
+      return state.execResult;
+    }
+  };
+
+  return { query, state };
+};
+
+// createChallengeModelStub wraps the query helper above and captures every call
+// the service makes. This keeps the tests focused on behavior instead of
+// runtime mocking libraries, which we do not have in this environment.
+const createChallengeModelStub = () => {
+  const { query, state } = createQueryStub();
+  let findOneQueue: Array<{ lean: () => Promise<ChallengeDocumentLike | null> }> = [];
+
+  const stub = {
+    findCalls: [] as Array<Record<string, unknown>>,
+    find(filter: Record<string, unknown>) {
+      stub.findCalls.push(filter);
+      return query;
+    },
+    findOneCalls: [] as Array<Record<string, unknown>>,
+    findOne(filter: Record<string, unknown>) {
+      stub.findOneCalls.push(filter);
+      const next = findOneQueue.shift();
+      if (!next) {
+        return {
+          async lean() {
+            return null;
+          }
+        };
+      }
+
+      return next;
+    },
+    setFindOneResponses(responses: Array<ChallengeDocumentLike | null>) {
+      findOneQueue = responses.map((value) => ({
+        async lean() {
+          return value;
+        }
+      }));
+    },
+    createInputs: [] as Array<Partial<ChallengeEntity>>,
+    async create(input: Partial<ChallengeEntity>) {
+      stub.createInputs.push(input);
+
+      return {
+        toObject() {
+          return {
+            ...input,
+            createdAt: new Date("2024-02-01T00:00:00.000Z"),
+            updatedAt: new Date("2024-02-01T00:00:00.000Z")
+          } as ChallengeDocumentLike;
+        }
+      };
+    },
+    queryState: state
+  };
+
+  return stub;
+};
+
+// The fixture helper gives each test a predictable challenge document while
+// still allowing targeted overrides for specific assertions.
+const createChallengeFixture = (
+  overrides: Partial<ChallengeDocumentLike> = {}
+): ChallengeDocumentLike => ({
+  slug: "sunset-sprint",
+  title: "Sunset Sprint",
+  tagline: "Chase the last light",
+  description: "Creators sprint through sunset challenges.",
+  goalCents: 50000,
+  raisedCents: 12000,
+  currency: "KES",
+  status: "live",
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+  ...overrides
+});
+
+test("AppService.getFeaturedChallenges normalizes filter parameters", async () => {
+  const modelStub = createChallengeModelStub();
+  const challenge = createChallengeFixture();
+  modelStub.queryState.execResult = [challenge];
+
+  const service = new AppService(modelStub as never);
+  const result = await service.getFeaturedChallenges({ status: "LIVE", limit: 3.9 });
+
+  assert.deepEqual(modelStub.findCalls[0], { status: "live" });
+  assert.equal(modelStub.queryState.limitArg, 3);
+
+  const expected: ChallengeSummary[] = [
+    {
+      id: challenge.slug,
+      title: challenge.title,
+      tagline: challenge.tagline,
+      raised: challenge.raisedCents,
+      goal: challenge.goalCents,
+      currency: challenge.currency
+    }
+  ];
+
+  assert.deepEqual(result, expected);
+});
+
+test("AppService.getChallenge returns a normalized challenge when found", async () => {
+  const modelStub = createChallengeModelStub();
+  const challenge = createChallengeFixture({ slug: "sunset-sprint" });
+  modelStub.setFindOneResponses([challenge]);
+
+  const service = new AppService(modelStub as never);
+  const result = await service.getChallenge("Sunset Sprint!!!");
+
+  assert.deepEqual(modelStub.findOneCalls[0], { slug: "sunset-sprint" });
+  assert.equal(result?.id, challenge.slug);
+  assert.equal(result?.status, challenge.status);
+  assert.equal(result?.createdAt, challenge.createdAt.toISOString());
+});
+
+test("AppService.createChallenge rejects duplicate slugs and persists valid payloads", async () => {
+  const modelStub = createChallengeModelStub();
+  modelStub.setFindOneResponses([null]);
+
+  const service = new AppService(modelStub as never);
+
+  const result = await service.createChallenge({
+    id: "Sunset Sprint",
+    title: " Sunset Sprint ",
+    tagline: " Chase momentum ",
+    description: " Harness the energy of golden hour. ",
+    goal: 50000,
+    currency: "kes",
+    status: "LIVE"
+  });
+
+  assert.equal(modelStub.createInputs.length, 1);
+  assert.deepEqual(modelStub.createInputs[0], {
+    slug: "sunset-sprint",
+    title: "Sunset Sprint",
+    tagline: "Chase momentum",
+    description: "Harness the energy of golden hour.",
+    goalCents: 50000,
+    raisedCents: 0,
+    currency: "KES",
+    status: "live"
+  });
+
+  assert.equal(result.id, "sunset-sprint");
+  assert.equal(result.goal, 50000);
+  assert.equal(result.currency, "KES");
+
+  modelStub.setFindOneResponses([createChallengeFixture({ slug: "sunset-sprint" })]);
+
+  await assert.rejects(
+    () =>
+      service.createChallenge({
+        id: "sunset-sprint",
+        title: "Duplicate",
+        tagline: "Duplicate",
+        description: "Duplicate",
+        goal: 100,
+        currency: "KES",
+        status: "draft"
+      }),
+    {
+      message: "A challenge with this id already exists."
+    }
+  );
+});

--- a/apps/api/tsconfig.test.json
+++ b/apps/api/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-tests",
+    "noEmit": false,
+    "typeRoots": ["../../types/custom"],
+    "types": [],
+    "baseUrl": ".",
+    "paths": {
+      "@trendpot/types": ["../../packages/types/src"]
+    }
+  },
+  "include": ["src/app.service.ts", "src/models/**/*.ts", "src/**/*.test.ts"],
+  "exclude": ["dist", "dist-tests"]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --check ."
+    "format": "prettier --check .",
+    "test": "NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src"
   },
   "dependencies": {
     "@tanstack/react-query": "5.37.1",

--- a/apps/web/src/lib/money.test.ts
+++ b/apps/web/src/lib/money.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { calculateCompletionPercentage, formatCurrencyFromCents } from "./money";
+
+// These tests provide fast feedback for the formatting helpers that power the
+// progress UI so we can refactor layouts later without second-guessing the math.
+test("formatCurrencyFromCents formats amounts with currency codes", () => {
+  const formatted = formatCurrencyFromCents(250000, "KES");
+  assert.match(formatted, /2,500/);
+  assert.ok(formatted.includes("K"));
+});
+
+test("calculateCompletionPercentage guards against divide-by-zero", () => {
+  const zeroGoal = calculateCompletionPercentage(100, 0);
+  assert.equal(zeroGoal, 0);
+
+  const capped = calculateCompletionPercentage(150, 100);
+  assert.equal(capped, 100);
+});

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist-tests",
+    "noEmit": false,
+    "typeRoots": ["../../types/custom"],
+    "baseUrl": ".",
+    "paths": {
+      "@trendpot/ui": ["../../packages/ui/src"],
+      "@trendpot/utils": ["../../packages/utils/src"],
+      "@trendpot/types": ["../../packages/types/src"]
+    }
+  },
+  "include": ["src/lib/**/*.ts", "src/**/*.test.ts"],
+  "exclude": ["dist-tests"]
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,8 @@
     "start": "node dist/index.js",
     "build": "tsc -p tsconfig.json",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
-    "format": "prettier --check \"src/**/*.{ts,tsx}\""
+    "format": "prettier --check \"src/**/*.{ts,tsx}\"",
+    "test": "NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src"
   },
   "dependencies": {
     "bullmq": "4.11.4",

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,24 +1,13 @@
 import { Queue, Worker } from "bullmq";
 import IORedis from "ioredis";
-import { challengeLeaderboardSchema } from "@trendpot/types";
 import { withRetries } from "@trendpot/utils";
+import { createLeaderboardJobHandler } from "./leaderboard-job";
 
 const connection = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6379");
 
 export const leaderboardQueue = new Queue("leaderboard", { connection });
 
-const jobHandler = async () => {
-  const payload = challengeLeaderboardSchema.parse({
-    generatedAt: new Date().toISOString(),
-    leaders: [
-      { id: "sunset-sprint", title: "Sunset Sprint", score: 98 },
-      { id: "duet-drive", title: "Duet Drive", score: 83 },
-      { id: "nightwave", title: "Nightwave", score: 75 }
-    ]
-  });
-
-  return payload;
-};
+const jobHandler = createLeaderboardJobHandler();
 
 const worker = new Worker(
   leaderboardQueue.name,

--- a/apps/worker/src/leaderboard-job.test.ts
+++ b/apps/worker/src/leaderboard-job.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { generateLeaderboardSnapshot, createLeaderboardJobHandler } from "./leaderboard-job";
+
+// The worker is tiny today, so validating the shape of its payload guards
+// against regressions as more complex scoring rules are introduced later on.
+test("generateLeaderboardSnapshot produces a schema compliant payload", () => {
+  const snapshot = generateLeaderboardSnapshot();
+
+  assert.equal(snapshot.leaders.length, 3);
+  snapshot.leaders.forEach((leader) => {
+    assert.ok(leader.id.length > 0);
+    assert.ok(leader.title.length > 0);
+    assert.ok(Number.isInteger(leader.score));
+  });
+});
+
+test("createLeaderboardJobHandler resolves to the same snapshot", async () => {
+  const handler = createLeaderboardJobHandler();
+  const snapshot = await handler();
+
+  assert.equal(snapshot.leaders.length, 3);
+});

--- a/apps/worker/src/leaderboard-job.ts
+++ b/apps/worker/src/leaderboard-job.ts
@@ -1,0 +1,27 @@
+import { challengeLeaderboardSchema } from "@trendpot/types";
+
+export interface LeaderboardSnapshot {
+  generatedAt: string;
+  leaders: Array<{ id: string; title: string; score: number }>;
+}
+
+// generateLeaderboardSnapshot centralizes the mock payload that the worker
+// currently emits so the job handler and the tests can depend on a single
+// source of truth.
+export const generateLeaderboardSnapshot = (): LeaderboardSnapshot => {
+  return challengeLeaderboardSchema.parse({
+    generatedAt: new Date().toISOString(),
+    leaders: [
+      { id: "sunset-sprint", title: "Sunset Sprint", score: 98 },
+      { id: "duet-drive", title: "Duet Drive", score: 83 },
+      { id: "nightwave", title: "Nightwave", score: 75 }
+    ]
+  });
+};
+
+// createLeaderboardJobHandler wraps the snapshot generator in an async function
+// so it matches the signature BullMQ expects and so tests can confirm the
+// handler always resolves to valid data.
+export const createLeaderboardJobHandler = () => {
+  return async () => generateLeaderboardSnapshot();
+};

--- a/apps/worker/tsconfig.test.json
+++ b/apps/worker/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-tests",
+    "noEmit": false,
+    "typeRoots": ["../../types/custom"],
+    "baseUrl": ".",
+    "paths": {
+      "@trendpot/types": ["../../packages/types/src"],
+      "@trendpot/utils": ["../../packages/utils/src"]
+    }
+  },
+  "include": ["src/leaderboard-job.ts", "src/**/*.test.ts"],
+  "exclude": ["dist", "dist-tests"]
+}

--- a/test-shims/@fastify/cors/index.js
+++ b/test-shims/@fastify/cors/index.js
@@ -1,0 +1,3 @@
+module.exports = function cors() {
+  return {};
+};

--- a/test-shims/@nestjs/common/index.js
+++ b/test-shims/@nestjs/common/index.js
@@ -1,0 +1,13 @@
+class BadRequestException extends Error {}
+const decorator = () => () => undefined;
+const Module = decorator;
+const Injectable = decorator;
+class Logger {
+  log() {
+    /* no-op for tests */
+  }
+  error() {
+    /* no-op for tests */
+  }
+}
+module.exports = { BadRequestException, Module, Injectable, Logger };

--- a/test-shims/@nestjs/graphql/index.js
+++ b/test-shims/@nestjs/graphql/index.js
@@ -1,0 +1,12 @@
+const decorator = () => () => undefined;
+const Resolver = decorator;
+const Query = decorator;
+const Mutation = decorator;
+const Args = decorator;
+const ObjectType = decorator;
+const Field = decorator;
+const InputType = decorator;
+const Int = {};
+const Float = {};
+const GraphQLISODateTime = {};
+module.exports = { Resolver, Query, Mutation, Args, ObjectType, Field, InputType, Int, Float, GraphQLISODateTime };

--- a/test-shims/@nestjs/mercurius/index.js
+++ b/test-shims/@nestjs/mercurius/index.js
@@ -1,0 +1,1 @@
+module.exports = { MercuriusDriver: {}, MercuriusDriverConfig: class {} };

--- a/test-shims/@nestjs/mongoose/index.js
+++ b/test-shims/@nestjs/mongoose/index.js
@@ -1,0 +1,26 @@
+const decorator = () => () => undefined;
+const InjectModel = decorator;
+const Schema = decorator;
+const Prop = decorator;
+const SchemaFactory = {
+  createForClass() {
+    return {
+      virtual() {
+        return {
+          get() {
+            return undefined;
+          }
+        };
+      }
+    };
+  }
+};
+const MongooseModule = {
+  forRoot() {
+    return {};
+  },
+  forFeature() {
+    return {};
+  }
+};
+module.exports = { InjectModel, Schema, Prop, SchemaFactory, MongooseModule };

--- a/test-shims/@nestjs/platform-fastify/index.js
+++ b/test-shims/@nestjs/platform-fastify/index.js
@@ -1,0 +1,2 @@
+class FastifyAdapter {}
+module.exports = { FastifyAdapter, NestFastifyApplication: class {} };

--- a/test-shims/@trendpot/types/index.js
+++ b/test-shims/@trendpot/types/index.js
@@ -1,0 +1,18 @@
+class TrendPotGraphQLClient {
+  constructor() {
+    /* placeholder client for tests */
+  }
+}
+const challengeLeaderboardSchema = {
+  parse(payload) {
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid payload");
+    }
+    const leaders = Array.isArray(payload.leaders) ? payload.leaders : [];
+    return {
+      generatedAt: typeof payload.generatedAt === "string" ? payload.generatedAt : new Date().toISOString(),
+      leaders
+    };
+  }
+};
+module.exports = { TrendPotGraphQLClient, challengeLeaderboardSchema };

--- a/test-shims/mongoose/index.js
+++ b/test-shims/mongoose/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  Schema: class Schema {},
+  model() {
+    return {};
+  },
+  connection: {},
+  Types: {
+    ObjectId: class ObjectId {}
+  }
+};

--- a/test-shims/ts-loader.mjs
+++ b/test-shims/ts-loader.mjs
@@ -1,0 +1,63 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const nodeDir = dirname(process.execPath);
+const typescriptPath = resolvePath(nodeDir, "..", "lib", "node_modules", "typescript", "lib", "typescript.js");
+const ts = await import(pathToFileURL(typescriptPath).href);
+const shimBase = new URL("./", import.meta.url);
+const shimMap = new Map([
+  ["@nestjs/common", new URL("@nestjs/common/index.js", shimBase).href],
+  ["@nestjs/mongoose", new URL("@nestjs/mongoose/index.js", shimBase).href],
+  ["@nestjs/graphql", new URL("@nestjs/graphql/index.js", shimBase).href],
+  ["@nestjs/mercurius", new URL("@nestjs/mercurius/index.js", shimBase).href],
+  ["@nestjs/platform-fastify", new URL("@nestjs/platform-fastify/index.js", shimBase).href],
+  ["@fastify/cors", new URL("@fastify/cors/index.js", shimBase).href],
+  ["mongoose", new URL("mongoose/index.js", shimBase).href],
+  ["@trendpot/types", new URL("@trendpot/types/index.js", shimBase).href]
+]);
+
+/**
+ * Minimal loader that transpiles TypeScript on the fly so we can run the Node
+ * test runner without pulling additional tooling.
+ */
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const parentUrl = context.parentURL ?? "file://";
+    const resolved = new URL(specifier, parentUrl);
+    if (!resolved.pathname.endsWith(".ts") && !resolved.pathname.endsWith(".js")) {
+      const tsUrl = new URL(`${specifier}.ts`, parentUrl);
+      return { url: tsUrl.href, shortCircuit: true };
+    }
+  }
+
+  if (shimMap.has(specifier)) {
+    return { url: shimMap.get(specifier), shortCircuit: true };
+  }
+
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith(".ts") || url.endsWith(".tsx")) {
+    const source = await readFile(new URL(url), "utf8");
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ES2020,
+        target: ts.ScriptTarget.ES2020,
+        esModuleInterop: true,
+        experimentalDecorators: true,
+        jsx: ts.JsxEmit.ReactJSX
+      },
+      fileName: url
+    });
+
+    return {
+      format: "module",
+      source: outputText,
+      shortCircuit: true
+    };
+  }
+
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/types/custom/index.d.ts
+++ b/types/custom/index.d.ts
@@ -1,0 +1,119 @@
+declare module "node:test" {
+  type TestFn = (t: unknown) => void | Promise<void>;
+  function test(name: string, fn: TestFn): Promise<void>;
+  function test(fn: TestFn): Promise<void>;
+  export = test;
+}
+
+declare module "node:assert/strict" {
+  interface Assert {
+    (value: unknown, message?: string): void;
+    equal(actual: unknown, expected: unknown, message?: string): void;
+    deepEqual(actual: unknown, expected: unknown, message?: string): void;
+    ok(value: unknown, message?: string): void;
+    rejects(block: () => Promise<unknown>, expected?: unknown): Promise<void>;
+  }
+  const assert: Assert;
+  export = assert;
+}
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    [key: string]: string | undefined;
+  }
+}
+
+declare const process: { env: NodeJS.ProcessEnv; uptime(): number; cwd(): string };
+
+declare module "node:path" {
+  export function join(...parts: string[]): string;
+}
+
+declare module "@nestjs/common" {
+  export const Module: (...args: unknown[]) => ClassDecorator;
+  export const Injectable: (...args: unknown[]) => ClassDecorator;
+  export class BadRequestException extends Error {}
+  export class Logger {
+    log(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+  }
+}
+
+declare module "@nestjs/core" {
+  export const NestFactory: {
+    create: (...args: unknown[]) => Promise<unknown>;
+  };
+}
+
+declare module "@nestjs/graphql" {
+  export const Resolver: (...args: unknown[]) => ClassDecorator;
+  export const Query: (...args: unknown[]) => MethodDecorator;
+  export const Mutation: (...args: unknown[]) => MethodDecorator;
+  export const Args: (...args: unknown[]) => ParameterDecorator;
+  export const ObjectType: (...args: unknown[]) => ClassDecorator;
+  export const Field: (...args: unknown[]) => PropertyDecorator;
+  export const InputType: (...args: unknown[]) => ClassDecorator;
+  export const Int: unknown;
+  export const Float: unknown;
+  export const GraphQLISODateTime: unknown;
+}
+
+declare module "@nestjs/mongoose" {
+  export const InjectModel: (...args: unknown[]) => ParameterDecorator;
+  export const MongooseModule: { forRoot: (...args: unknown[]) => unknown; forFeature: (...args: unknown[]) => unknown };
+  export const Schema: (...args: unknown[]) => ClassDecorator;
+  export const Prop: (...args: unknown[]) => PropertyDecorator;
+  export const SchemaFactory: { createForClass: (...args: unknown[]) => unknown };
+}
+
+declare module "@nestjs/mercurius" {
+  export const MercuriusDriver: unknown;
+  export interface MercuriusDriverConfig {}
+}
+
+declare module "@nestjs/platform-fastify" {
+  export class FastifyAdapter {}
+  export type NestFastifyApplication = unknown;
+}
+
+declare module "@fastify/cors" {
+  const cors: (...args: unknown[]) => unknown;
+  export default cors;
+}
+
+declare module "mongoose" {
+  export type Model<T> = {
+    find: (...args: unknown[]) => unknown;
+    findOne: (...args: unknown[]) => unknown;
+    create: (...args: unknown[]) => Promise<{ toObject(): T }>;
+  };
+  export type HydratedDocument<T> = T;
+}
+
+declare module "@trendpot/types" {
+  export interface ChallengeSummary {
+    id: string;
+    title: string;
+    tagline: string;
+    raised: number;
+    goal: number;
+    currency: string;
+  }
+  export interface Challenge extends ChallengeSummary {
+    description: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+  }
+  export interface ListChallengesParams {
+    status?: string;
+    limit?: number;
+  }
+  export type CreateChallengeInput = unknown;
+  export const challengeLeaderboardSchema: {
+    parse<T>(input: T): T;
+  };
+  export class TrendPotGraphQLClient {
+    constructor(...args: unknown[]);
+  }
+}


### PR DESCRIPTION
## Summary
- add shared Node-based test scripts for the api, web, and worker packages using a lightweight TypeScript loader
- cover AppService, leaderboard job generation, and money helpers with focused unit tests
- document milestone progress in the development tracker and add local type shims/stubs needed for the harness

## Testing
- NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src/app.service.test.ts (apps/api)
- NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src/leaderboard-job.test.ts (apps/worker)
- NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src/lib/money.test.ts (apps/web)

------
https://chatgpt.com/codex/tasks/task_e_68d5465c2094832eb80f998787df5cd4