### PR TITLE
feat(api): enforce graphql auth guards and rate limiting

### DIFF
--- a/DEVELOPMENT_TRACKER.md
+++ b/DEVELOPMENT_TRACKER.md
@@ -132,9 +132,9 @@
 
 ## 3. In-House Authentication & Access Control
 - ☐ **Build internal auth service (user store, passwordless/email OTP or similar) with secure session issuance.** _(Owner: Platform)_
-  - Notes:
+  - Notes: 2025-10-05 – AI – Documented Phase 0 auth alignment (roles, permissions, data models) in `docs/design/auth-alignment.md` and shared Zod contracts.
 - ☐ **Enforce role-based guards on GraphQL resolvers and admin routes, including rate limiting.** _(Owner: Backend)_
-  - Notes:
+  - Notes: 2025-10-05 – AI – Introduced auth context parsing, viewer contract, role guard, and rate limiter covering admin GraphQL resolvers with audit logging.
 - ☐ **Restrict CORS to approved origins and introduce Helmet + security headers across API.** _(Owner: Platform)_
   - Notes:
 - ☐ **Produce responsive UX for login/signup/account management (desktop & mobile).** _(Owner: Frontend)_

--- a/apps/api/schema.gql
+++ b/apps/api/schema.gql
@@ -4,6 +4,19 @@ enum ChallengeStatus {
   ARCHIVED
 }
 
+enum UserRole {
+  FAN
+  CREATOR
+  OPERATOR
+  ADMIN
+}
+
+enum UserStatus {
+  ACTIVE
+  DISABLED
+  PENDING_VERIFICATION
+}
+
 type ChallengeSummary {
   id: String!
   title: String!
@@ -66,6 +79,32 @@ type Health {
   uptime: Float!
 }
 
+type ViewerUser {
+  id: String!
+  email: String!
+  phone: String
+  displayName: String!
+  roles: [UserRole!]!
+  permissions: [String!]!
+  status: UserStatus!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type ViewerSession {
+  id: String!
+  issuedAt: DateTime!
+  expiresAt: DateTime!
+  ipAddress: String
+  userAgent: String
+  status: String!
+}
+
+type Viewer {
+  user: ViewerUser
+  session: ViewerSession
+}
+
 input ChallengeListFilterInput {
   status: ChallengeStatus
   search: String
@@ -109,6 +148,7 @@ type Query {
   challengeAdminList(input: ChallengeListInput): ChallengeList!
   challenge(id: String!): Challenge
   health: Health!
+  viewer: Viewer!
 }
 
 type Mutation {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,11 +1,17 @@
 import { join } from "node:path";
 import { Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
 import { GraphQLModule } from "@nestjs/graphql";
 import { MongooseModule } from "@nestjs/mongoose";
 import { MercuriusDriver, MercuriusDriverConfig } from "@nestjs/mercurius";
+import { AuthAuditService } from "./auth/auth-audit.service";
+import { RateLimitGuard } from "./auth/rate-limit.guard";
+import { RateLimitService } from "./auth/rate-limit.service";
+import { RolesGuard } from "./auth/roles.guard";
 import { AppService } from "./app.service";
 import { ChallengeResolver } from "./challenge.resolver";
 import { HealthResolver } from "./health.resolver";
+import { AuthResolver } from "./models/auth.resolver";
 import { ChallengeEntity, ChallengeSchema } from "./models/challenge.schema";
 import { buildGraphQLContext } from "./observability/graphql-context";
 import { structuredErrorFormatter } from "./observability/error-formatter";
@@ -23,6 +29,21 @@ import { structuredErrorFormatter } from "./observability/error-formatter";
     MongooseModule.forRoot(process.env.MONGODB_URI ?? "mongodb://localhost:27017/trendpot"),
     MongooseModule.forFeature([{ name: ChallengeEntity.name, schema: ChallengeSchema }])
   ],
-  providers: [AppService, ChallengeResolver, HealthResolver]
+  providers: [
+    AppService,
+    ChallengeResolver,
+    HealthResolver,
+    AuthResolver,
+    AuthAuditService,
+    RateLimitService,
+    {
+      provide: APP_GUARD,
+      useClass: RateLimitGuard
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard
+    }
+  ]
 })
 export class AppModule {}

--- a/apps/api/src/auth/auth-audit.service.ts
+++ b/apps/api/src/auth/auth-audit.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from "@nestjs/common";
+import type { Logger } from "pino";
+import type { UserRole } from "@trendpot/types";
+
+interface AuditFailurePayload {
+  requestId: string;
+  operation: string;
+  reason: string;
+  logger: Logger;
+  userId?: string;
+  roles?: UserRole[];
+  ipAddress?: string;
+}
+
+@Injectable()
+export class AuthAuditService {
+  recordAuthorizationFailure(payload: AuditFailurePayload) {
+    const { logger, ...details } = payload;
+    logger.warn({ event: "auth.authorization_failure", ...details }, "Authorization failure detected");
+  }
+
+  recordRateLimitViolation(payload: AuditFailurePayload & { retryAt: number }) {
+    const { logger, retryAt, ...details } = payload;
+    logger.warn(
+      {
+        event: "auth.rate_limit_violation",
+        retryAt,
+        ...details
+      },
+      "Rate limit triggered"
+    );
+  }
+}

--- a/apps/api/src/auth/auth-context.ts
+++ b/apps/api/src/auth/auth-context.ts
@@ -1,0 +1,69 @@
+import { Buffer } from "node:buffer";
+import type { FastifyRequest } from "fastify";
+import type { Logger } from "pino";
+import { sessionSchema, userSchema } from "@trendpot/types";
+import { z } from "zod";
+import type { ResolvedAuthContext } from "./auth.types";
+
+const base64PayloadSchema = z
+  .string()
+  .min(1)
+  .transform((value) => {
+    try {
+      const decoded = Buffer.from(value, "base64url").toString("utf8");
+      return JSON.parse(decoded) as unknown;
+    } catch (error) {
+      throw new Error("INVALID_BASE64_JSON");
+    }
+  });
+
+const headersSchema = z.object({
+  user: base64PayloadSchema.optional(),
+  session: base64PayloadSchema.optional()
+});
+
+export const resolveAuthContext = (
+  request: FastifyRequest,
+  logger: Logger
+): ResolvedAuthContext => {
+  const headers = headersSchema.safeParse({
+    user: typeof request.headers["x-trendpot-user"] === "string" ? request.headers["x-trendpot-user"] : undefined,
+    session:
+      typeof request.headers["x-trendpot-session"] === "string" ? request.headers["x-trendpot-session"] : undefined
+  });
+
+  let user: ResolvedAuthContext["user"] = null;
+  let session: ResolvedAuthContext["session"] = null;
+
+  if (!headers.success) {
+    const reason = headers.error.issues[0]?.message ?? "invalid auth headers";
+    logger.debug({ reason }, "Failed to parse auth headers");
+    return { user, session };
+  }
+
+  if (headers.data.user) {
+    try {
+      user = userSchema.parse(headers.data.user);
+    } catch (error) {
+      logger.warn({ error }, "Rejected malformed user payload from auth header");
+    }
+  }
+
+  if (headers.data.session) {
+    try {
+      const parsed = sessionSchema.parse(headers.data.session);
+      session = {
+        id: parsed.id,
+        issuedAt: parsed.issuedAt,
+        expiresAt: parsed.expiresAt,
+        ipAddress: parsed.ipAddress,
+        userAgent: parsed.userAgent,
+        status: parsed.status
+      };
+    } catch (error) {
+      logger.warn({ error }, "Rejected malformed session payload from auth header");
+    }
+  }
+
+  return { user, session };
+};

--- a/apps/api/src/auth/auth.decorators.ts
+++ b/apps/api/src/auth/auth.decorators.ts
@@ -1,0 +1,16 @@
+import { SetMetadata } from "@nestjs/common";
+import type { UserRole } from "@trendpot/types";
+
+export const ROLES_KEY = Symbol("roles");
+export const ALLOW_ANONYMOUS_KEY = Symbol("allow_anonymous");
+export const RATE_LIMIT_KEY = Symbol("rate_limit");
+
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
+export const AllowAnonymous = () => SetMetadata(ALLOW_ANONYMOUS_KEY, true);
+
+export interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+}
+
+export const RateLimit = (options: RateLimitOptions) => SetMetadata(RATE_LIMIT_KEY, options);

--- a/apps/api/src/auth/auth.types.ts
+++ b/apps/api/src/auth/auth.types.ts
@@ -1,0 +1,11 @@
+import type { Session, User } from "@trendpot/types";
+
+export interface AuthenticatedUser extends User {}
+
+export interface AuthenticatedSession
+  extends Pick<Session, "id" | "issuedAt" | "expiresAt" | "ipAddress" | "userAgent" | "status"> {}
+
+export interface ResolvedAuthContext {
+  user: AuthenticatedUser | null;
+  session: AuthenticatedSession | null;
+}

--- a/apps/api/src/auth/rate-limit.guard.ts
+++ b/apps/api/src/auth/rate-limit.guard.ts
@@ -1,0 +1,54 @@
+import { CanActivate, ExecutionContext, Injectable, TooManyRequestsException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { GqlExecutionContext } from "@nestjs/graphql";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../observability/graphql-context";
+import { AuthAuditService } from "./auth-audit.service";
+import { RATE_LIMIT_KEY, type RateLimitOptions } from "./auth.decorators";
+import { RateLimitService } from "./rate-limit.service";
+
+const DEFAULT_RATE_LIMIT: RateLimitOptions = {
+  windowMs: 60_000,
+  max: 60
+};
+
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly rateLimitService: RateLimitService,
+    private readonly audit: AuthAuditService
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const gqlContext = GqlExecutionContext.create(context);
+    const info = gqlContext.getInfo<GraphQLResolveInfo>();
+    const ctx = gqlContext.getContext<GraphQLContext>();
+
+    const options =
+      this.reflector.getAllAndOverride<RateLimitOptions>(RATE_LIMIT_KEY, [
+        context.getHandler(),
+        context.getClass()
+      ]) ?? DEFAULT_RATE_LIMIT;
+
+    const identifier = `${ctx.request.ip ?? "unknown"}:${info.fieldName}`;
+    const { allowed, retryAt } = this.rateLimitService.consume(identifier, options);
+
+    if (!allowed) {
+      this.audit.recordRateLimitViolation({
+        requestId: ctx.requestId,
+        operation: info.fieldName,
+        reason: "rate_limited",
+        logger: ctx.logger,
+        userId: ctx.user?.id,
+        roles: ctx.user?.roles,
+        ipAddress: ctx.request.ip,
+        retryAt
+      });
+      ctx.reply.header("Retry-After", Math.ceil((retryAt - Date.now()) / 1000));
+      throw new TooManyRequestsException("Too many requests. Please try again later.");
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/auth/rate-limit.service.ts
+++ b/apps/api/src/auth/rate-limit.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import type { RateLimitOptions } from "./auth.decorators";
+
+interface RateLimitBucket {
+  count: number;
+  resetAt: number;
+}
+
+@Injectable()
+export class RateLimitService {
+  private readonly buckets = new Map<string, RateLimitBucket>();
+
+  consume(key: string, options: RateLimitOptions): { allowed: boolean; retryAt: number } {
+    const now = Date.now();
+    const existing = this.buckets.get(key);
+
+    if (!existing || existing.resetAt <= now) {
+      this.buckets.set(key, { count: 1, resetAt: now + options.windowMs });
+      return { allowed: true, retryAt: now + options.windowMs };
+    }
+
+    if (existing.count >= options.max) {
+      return { allowed: false, retryAt: existing.resetAt };
+    }
+
+    existing.count += 1;
+    this.buckets.set(key, existing);
+    return { allowed: true, retryAt: existing.resetAt };
+  }
+}

--- a/apps/api/src/auth/roles.guard.ts
+++ b/apps/api/src/auth/roles.guard.ts
@@ -1,0 +1,62 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { GqlExecutionContext } from "@nestjs/graphql";
+import type { GraphQLResolveInfo } from "graphql";
+import type { GraphQLContext } from "../observability/graphql-context";
+import { AuthAuditService } from "./auth-audit.service";
+import { ALLOW_ANONYMOUS_KEY, ROLES_KEY } from "./auth.decorators";
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector, private readonly audit: AuthAuditService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const allowAnonymous = this.reflector.getAllAndOverride<boolean>(ALLOW_ANONYMOUS_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ]);
+
+    if (allowAnonymous) {
+      return true;
+    }
+
+    const gqlContext = GqlExecutionContext.create(context);
+    const info = gqlContext.getInfo<GraphQLResolveInfo>();
+    const ctx = gqlContext.getContext<GraphQLContext>();
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass()
+    ]);
+
+    const operationName = info.fieldName;
+
+    if (!ctx.user) {
+      this.audit.recordAuthorizationFailure({
+        requestId: ctx.requestId,
+        operation: operationName,
+        reason: "missing_session",
+        logger: ctx.logger,
+        ipAddress: ctx.request.ip
+      });
+      throw new UnauthorizedException("Authentication is required to access this resource.");
+    }
+
+    if (requiredRoles && requiredRoles.length > 0) {
+      const hasRole = ctx.user.roles.some((role) => requiredRoles.includes(role));
+      if (!hasRole) {
+        this.audit.recordAuthorizationFailure({
+          requestId: ctx.requestId,
+          operation: operationName,
+          reason: "insufficient_role",
+          logger: ctx.logger,
+          userId: ctx.user.id,
+          roles: ctx.user.roles,
+          ipAddress: ctx.request.ip
+        });
+        throw new ForbiddenException("You do not have permission to perform this action.");
+      }
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/challenge.resolver.ts
+++ b/apps/api/src/challenge.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
 import type { ListChallengesParams } from "@trendpot/types";
+import { AllowAnonymous, RateLimit, Roles } from "./auth/auth.decorators";
 import { AppService } from "./app.service";
 import { ChallengeListModel } from "./models/challenge-list.model";
 import { ChallengeModel } from "./models/challenge.model";
@@ -12,6 +13,7 @@ import { ArchiveChallengeInputModel, UpdateChallengeInputModel } from "./models/
 export class ChallengeResolver {
   constructor(private readonly appService: AppService) {}
 
+  @AllowAnonymous()
   @Query(() => [ChallengeSummaryModel], { name: "featuredChallenges" })
   async featuredChallenges(
     @Args("status", { type: () => String, nullable: true }) status?: string,
@@ -30,6 +32,7 @@ export class ChallengeResolver {
     return this.appService.getFeaturedChallenges(params);
   }
 
+  @AllowAnonymous()
   @Query(() => [ChallengeSummaryModel], { name: "challenges" })
   async challenges(
     @Args("status", { type: () => String, nullable: true }) status?: string,
@@ -48,26 +51,35 @@ export class ChallengeResolver {
     return this.appService.listChallenges(params);
   }
 
+  @Roles("admin", "operator")
+  @RateLimit({ windowMs: 60_000, max: 20 })
   @Query(() => ChallengeListModel, { name: "challengeAdminList" })
   async challengeAdminList(@Args("input", { type: () => ChallengeListInputModel, nullable: true }) input?: ChallengeListInputModel) {
     return this.appService.paginateChallenges(input ?? {});
   }
 
+  @AllowAnonymous()
   @Query(() => ChallengeModel, { name: "challenge", nullable: true })
   async challenge(@Args("id", { type: () => String }) id: string) {
     return this.appService.getChallenge(id);
   }
 
+  @Roles("admin", "operator")
+  @RateLimit({ windowMs: 60_000, max: 10 })
   @Mutation(() => ChallengeModel, { name: "createChallenge" })
   async createChallenge(@Args("input") input: CreateChallengeInputModel) {
     return this.appService.createChallenge(input);
   }
 
+  @Roles("admin", "operator")
+  @RateLimit({ windowMs: 60_000, max: 15 })
   @Mutation(() => ChallengeModel, { name: "updateChallenge" })
   async updateChallenge(@Args("input") input: UpdateChallengeInputModel) {
     return this.appService.updateChallenge(input);
   }
 
+  @Roles("admin", "operator")
+  @RateLimit({ windowMs: 60_000, max: 10 })
   @Mutation(() => ChallengeModel, { name: "archiveChallenge" })
   async archiveChallenge(@Args("input") input: ArchiveChallengeInputModel) {
     return this.appService.archiveChallenge(input);

--- a/apps/api/src/health.resolver.ts
+++ b/apps/api/src/health.resolver.ts
@@ -1,4 +1,5 @@
 import { Float, ObjectType, Field, Query, Resolver } from "@nestjs/graphql";
+import { AllowAnonymous } from "./auth/auth.decorators";
 
 @ObjectType("Health")
 class HealthPayload {
@@ -14,6 +15,7 @@ class HealthPayload {
 
 @Resolver()
 export class HealthResolver {
+  @AllowAnonymous()
   @Query(() => HealthPayload)
   health(): HealthPayload {
     return { status: "ok", service: "trendpot-api", uptime: process.uptime() };

--- a/apps/api/src/models/auth.resolver.ts
+++ b/apps/api/src/models/auth.resolver.ts
@@ -1,0 +1,13 @@
+import { Context, Query, Resolver } from "@nestjs/graphql";
+import { AllowAnonymous } from "../auth/auth.decorators";
+import type { GraphQLContext } from "../observability/graphql-context";
+import { ViewerModel } from "./viewer.model";
+
+@Resolver(() => ViewerModel)
+export class AuthResolver {
+  @AllowAnonymous()
+  @Query(() => ViewerModel, { name: "viewer" })
+  viewer(@Context() context: GraphQLContext) {
+    return ViewerModel.fromContext({ user: context.user, session: context.session });
+  }
+}

--- a/apps/api/src/models/user-role.enum.ts
+++ b/apps/api/src/models/user-role.enum.ts
@@ -1,0 +1,29 @@
+import { registerEnumType } from "@nestjs/graphql";
+import type { UserRole as UserRoleContract } from "@trendpot/types";
+
+export enum UserRoleModel {
+  Fan = "fan",
+  Creator = "creator",
+  Operator = "operator",
+  Admin = "admin"
+}
+
+registerEnumType(UserRoleModel, {
+  name: "UserRole",
+  description: "Role assigned to an authenticated user that drives authorization across the platform."
+});
+
+export const toUserRoleModel = (role: UserRoleContract): UserRoleModel => {
+  switch (role) {
+    case "fan":
+      return UserRoleModel.Fan;
+    case "creator":
+      return UserRoleModel.Creator;
+    case "operator":
+      return UserRoleModel.Operator;
+    case "admin":
+      return UserRoleModel.Admin;
+    default:
+      return UserRoleModel.Fan;
+  }
+};

--- a/apps/api/src/models/user-status.enum.ts
+++ b/apps/api/src/models/user-status.enum.ts
@@ -1,0 +1,26 @@
+import { registerEnumType } from "@nestjs/graphql";
+import type { UserStatus as UserStatusContract } from "@trendpot/types";
+
+export enum UserStatusModel {
+  Active = "active",
+  Disabled = "disabled",
+  PendingVerification = "pending_verification"
+}
+
+registerEnumType(UserStatusModel, {
+  name: "UserStatus",
+  description: "Lifecycle state representing whether the user can authenticate."
+});
+
+export const toUserStatusModel = (status: UserStatusContract): UserStatusModel => {
+  switch (status) {
+    case "active":
+      return UserStatusModel.Active;
+    case "disabled":
+      return UserStatusModel.Disabled;
+    case "pending_verification":
+      return UserStatusModel.PendingVerification;
+    default:
+      return UserStatusModel.Disabled;
+  }
+};

--- a/apps/api/src/models/viewer-session.model.ts
+++ b/apps/api/src/models/viewer-session.model.ts
@@ -1,0 +1,34 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import type { AuthenticatedSession } from "../auth/auth.types";
+
+@ObjectType("ViewerSession")
+export class ViewerSessionModel {
+  @Field()
+  declare id: string;
+
+  @Field(() => Date)
+  declare issuedAt: Date;
+
+  @Field(() => Date)
+  declare expiresAt: Date;
+
+  @Field({ nullable: true })
+  declare ipAddress?: string | null;
+
+  @Field({ nullable: true })
+  declare userAgent?: string | null;
+
+  @Field()
+  declare status: string;
+
+  static fromSession(session: AuthenticatedSession): ViewerSessionModel {
+    const model = new ViewerSessionModel();
+    model.id = session.id;
+    model.issuedAt = new Date(session.issuedAt);
+    model.expiresAt = new Date(session.expiresAt);
+    model.ipAddress = session.ipAddress ?? null;
+    model.userAgent = session.userAgent ?? null;
+    model.status = session.status;
+    return model;
+  }
+}

--- a/apps/api/src/models/viewer-user.model.ts
+++ b/apps/api/src/models/viewer-user.model.ts
@@ -1,0 +1,48 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import type { AuthenticatedUser } from "../auth/auth.types";
+import { toUserRoleModel, UserRoleModel } from "./user-role.enum";
+import { toUserStatusModel, UserStatusModel } from "./user-status.enum";
+
+@ObjectType("ViewerUser")
+export class ViewerUserModel {
+  @Field()
+  declare id: string;
+
+  @Field()
+  declare email: string;
+
+  @Field({ nullable: true })
+  declare phone?: string | null;
+
+  @Field()
+  declare displayName: string;
+
+  @Field(() => [UserRoleModel])
+  declare roles: UserRoleModel[];
+
+  @Field(() => [String])
+  declare permissions: string[];
+
+  @Field(() => UserStatusModel)
+  declare status: UserStatusModel;
+
+  @Field(() => Date)
+  declare createdAt: Date;
+
+  @Field(() => Date)
+  declare updatedAt: Date;
+
+  static fromUser(user: AuthenticatedUser): ViewerUserModel {
+    const model = new ViewerUserModel();
+    model.id = user.id;
+    model.email = user.email;
+    model.phone = user.phone ?? null;
+    model.displayName = user.displayName;
+    model.roles = user.roles.map((role) => toUserRoleModel(role));
+    model.permissions = user.permissions;
+    model.status = toUserStatusModel(user.status);
+    model.createdAt = new Date(user.createdAt);
+    model.updatedAt = new Date(user.updatedAt);
+    return model;
+  }
+}

--- a/apps/api/src/models/viewer.model.ts
+++ b/apps/api/src/models/viewer.model.ts
@@ -1,0 +1,20 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import type { AuthenticatedSession, AuthenticatedUser } from "../auth/auth.types";
+import { ViewerSessionModel } from "./viewer-session.model";
+import { ViewerUserModel } from "./viewer-user.model";
+
+@ObjectType("Viewer")
+export class ViewerModel {
+  @Field(() => ViewerUserModel, { nullable: true })
+  declare user: ViewerUserModel | null;
+
+  @Field(() => ViewerSessionModel, { nullable: true })
+  declare session: ViewerSessionModel | null;
+
+  static fromContext(context: { user: AuthenticatedUser | null; session: AuthenticatedSession | null }) {
+    const model = new ViewerModel();
+    model.user = context.user ? ViewerUserModel.fromUser(context.user) : null;
+    model.session = context.session ? ViewerSessionModel.fromSession(context.session) : null;
+    return model;
+  }
+}

--- a/apps/api/src/observability/graphql-context.ts
+++ b/apps/api/src/observability/graphql-context.ts
@@ -1,11 +1,15 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import type { MercuriusContext } from "mercurius";
 import type { Logger } from "pino";
+import { resolveAuthContext } from "../auth/auth-context";
+import type { AuthenticatedSession, AuthenticatedUser } from "../auth/auth.types";
 import { createRequestLogger } from "./logger";
 
 export interface GraphQLContext extends MercuriusContext {
   requestId: string;
   logger: Logger;
+  user: AuthenticatedUser | null;
+  session: AuthenticatedSession | null;
 }
 
 /**
@@ -13,18 +17,22 @@ export interface GraphQLContext extends MercuriusContext {
  * The reply header is also populated so clients can correlate errors
  * using the same identifier captured in logs.
  */
-export const buildGraphQLContext = (
+export const buildGraphQLContext = async (
   request: FastifyRequest,
   reply: FastifyReply
-): GraphQLContext => {
+): Promise<GraphQLContext> => {
   const requestId = String(request.id);
   reply.header("x-request-id", requestId);
+  const logger = createRequestLogger(requestId);
+  const auth = resolveAuthContext(request, logger);
 
   return {
     app: reply.server,
     reply,
     request,
     requestId,
-    logger: createRequestLogger(requestId)
+    logger,
+    user: auth.user,
+    session: auth.session
   };
 };

--- a/docs/design/auth-alignment.md
+++ b/docs/design/auth-alignment.md
@@ -1,0 +1,110 @@
+# In-House Authentication Alignment (Phase 0)
+
+## Purpose
+This document captures the shared understanding for Milestone 3 (In-House Authentication & Access Control) so every team can execute against the same contracts. It summarizes user roles, mapped permissions, and Mongo data modeling decisions for auth-related collections. These decisions are the source of truth for Platform, Backend, and Frontend workstreams.
+
+## User Roles & Permissions
+The platform supports four primary user roles. Permissions are intentionally granular so guards can be enforced consistently across API resolvers, admin routes, and frontend clients.
+
+| Role | Description | Key Permissions |
+| --- | --- | --- |
+| `fan` | Supporters who register to follow creators and donate to challenges. | `view_public_profile`, `initiate_donation`, `manage_own_sessions`, `update_own_profile` |
+| `creator` | Challenge owners publishing content, managing submissions, and engaging with donors. | All `fan` permissions plus `manage_own_challenges`, `view_own_donations`, `manage_own_submissions`, `manage_creator_profile` |
+| `operator` | Trust & safety / support staff resolving tickets and managing compliance records. | All `creator` permissions plus `view_all_donations`, `view_audit_logs`, `manage_sessions`, `flag_content`, `resolve_support_cases` |
+| `admin` | Platform administrators owning configuration, payouts, and high-risk actions. | All `operator` permissions plus `manage_all_challenges`, `manage_roles`, `manage_payouts`, `manage_security_settings`, `manage_rate_limits` |
+
+### Permission Catalogue
+- `view_public_profile`: Read-only access to public creator/fan information and challenge listings.
+- `initiate_donation`: Start payment flows (e.g., M-Pesa STK push) against eligible challenges.
+- `manage_own_sessions`: Create/revoke personal sessions, refresh tokens, and view login history.
+- `update_own_profile`: Edit personal contact preferences, bio, and notification settings.
+- `manage_own_challenges`: Create, edit, archive, and publish owned challenges.
+- `view_own_donations`: Access donation telemetry and payout summaries tied to owned challenges.
+- `manage_own_submissions`: Moderate creator submissions, respond to donor feedback, and publish updates.
+- `manage_creator_profile`: Manage creator-specific settings, links, and feature flags.
+- `view_all_donations`: View donation ledgers across the platform for compliance/reconciliation.
+- `view_audit_logs`: Read immutable audit trails for sensitive actions.
+- `manage_sessions`: Revoke active sessions for any user (support-level capability).
+- `flag_content`: Escalate or quarantine content that violates policies.
+- `resolve_support_cases`: Close, annotate, or transfer support tickets.
+- `manage_all_challenges`: Override challenge states, edit metadata, or migrate ownership.
+- `manage_roles`: Assign or revoke roles for any user.
+- `manage_payouts`: Configure creator payout schedules and mark disbursements complete.
+- `manage_security_settings`: Adjust security headers, session policies, and auth factor requirements.
+- `manage_rate_limits`: Tune rate limiting thresholds for APIs and auth factors.
+
+## Shared Zod Contracts
+To guarantee alignment, the shared `@trendpot/types` package now exports `auth` schemas that encode the above roles and permissions, along with canonical shapes for users, auth factors, sessions, and audit log entries. All teams must import from `@trendpot/types/auth` (or the aggregate index) instead of redefining ad-hoc types. This ensures:
+
+1. GraphQL context and resolvers enforce identical role/permission enums.
+2. Frontend clients rely on the same discriminated unions when rendering gated experiences.
+3. Worker jobs use consistent identifiers when processing sessions or audit events.
+
+### GraphQL Context Header Contract
+- **Headers**: `X-TrendPot-User` and `X-TrendPot-Session` carry base64url-encoded JSON payloads that conform to the shared `userSchema` and `sessionSchema`. Backend resolvers decode these values to populate the GraphQL context and feed authorization guards.
+- **Viewer Query**: A new `viewer` query returns the decoded payload using the shared `viewerSchema`, enabling the frontend to hydrate session-aware UX without duplicating parsing logic.
+- **Failure Handling**: Malformed payloads are rejected and logged via the auth audit service; guards treat missing/invalid headers as unauthenticated requests.
+
+## Mongo Data Modeling Decisions
+Collections follow existing repository guidance: ObjectId foreign keys, referencing relationships, and TTL indexes for ephemeral documents.
+
+### `users`
+- **Indexes**: Unique compound on `{ email: 1 }`, optional unique on `{ phone: 1 }`, and sparse index on `handle` for creators.
+- **Fields**:
+  - `_id`: ObjectId
+  - `email`: string (lowercased)
+  - `phone`: optional string in E.164
+  - `roles`: array of `UserRole`
+  - `displayName`: string
+  - `status`: enum (`active`, `disabled`, `pending_verification`)
+  - `createdAt` / `updatedAt`: ISO strings
+  - `metadata`: object for feature flags, locales, and notification preferences
+- **Rationale**: Keep authentication factors separate; user document focuses on identity and platform-facing attributes.
+
+### `auth_factors`
+- **Indexes**: Compound unique on `{ userId: 1, type: 1, channel: 1 }`; TTL index on `expiresAt` for OTPs.
+- **Fields**:
+  - `_id`: ObjectId
+  - `userId`: ObjectId reference to `users`
+  - `type`: enum (`email_otp`, `magic_link`)
+  - `channel`: string (`email`, `phone`)
+  - `secretHash`: string (hashed OTP or token)
+  - `attempts`: number (int, defaults to 0)
+  - `expiresAt`: Date
+  - `createdAt`: Date
+  - `status`: enum (`active`, `consumed`, `expired`, `revoked`)
+- **Rationale**: Supports passwordless flows with per-factor lifecycle management and auditing.
+
+### `sessions`
+- **Indexes**: Unique on `refreshTokenHash`; TTL on `expiresAt`; compound on `{ userId: 1, createdAt: -1 }` for history queries.
+- **Fields**:
+  - `_id`: ObjectId
+  - `userId`: ObjectId reference to `users`
+  - `rolesSnapshot`: array of `UserRole` captured at issuance
+  - `issuedAt`: Date
+  - `expiresAt`: Date
+  - `refreshTokenHash`: string
+  - `ipAddress`: string
+  - `userAgent`: string
+  - `status`: enum (`active`, `revoked`, `expired`)
+  - `metadata`: object (device labels, risk flags)
+- **Rationale**: Maintains revocation controls and auditability for session management.
+
+### `audit_logs`
+- **Indexes**: Compound on `{ actorId: 1, createdAt: -1 }`, and TTL optional for low-sensitivity entries if retention policies allow; full-text index on `context.summary` for support.
+- **Fields**:
+  - `_id`: ObjectId
+  - `actorId`: ObjectId reference to `users`
+  - `actorRoles`: array of `UserRole`
+  - `action`: enum (`auth.login`, `auth.logout`, `auth.factor.enroll`, `auth.factor.challenge`, `auth.session.revoke`, `security.settings.update`, etc.)
+  - `target`: optional ObjectId or string reference to impacted resource
+  - `context`: object containing request metadata (IP, user agent, requestId)
+  - `createdAt`: Date
+  - `severity`: enum (`info`, `warning`, `critical`)
+- **Rationale**: Centralizes traceability for sensitive operations and feeds observability pipelines.
+
+## Next Steps
+- Platform team to scaffold NestJS modules using the above schemas for user creation and auth factor issuance.
+- Backend team to integrate role-based guards using `userRoleSchema` and `permissionSchema` exports.
+- Frontend team to consume the new contracts for gating routes/components while UX flows are designed.
+- Add integration tests verifying serialization/deserialization of the shared contracts once API endpoints are implemented.

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,198 @@
+import { z } from "zod";
+
+export const userRoleSchema = z.enum(["fan", "creator", "operator", "admin"]);
+export type UserRole = z.infer<typeof userRoleSchema>;
+
+export const userPermissionSchema = z.enum([
+  "view_public_profile",
+  "initiate_donation",
+  "manage_own_sessions",
+  "update_own_profile",
+  "manage_own_challenges",
+  "view_own_donations",
+  "manage_own_submissions",
+  "manage_creator_profile",
+  "view_all_donations",
+  "view_audit_logs",
+  "manage_sessions",
+  "flag_content",
+  "resolve_support_cases",
+  "manage_all_challenges",
+  "manage_roles",
+  "manage_payouts",
+  "manage_security_settings",
+  "manage_rate_limits"
+]);
+export type UserPermission = z.infer<typeof userPermissionSchema>;
+
+const fanPermissions = [
+  "view_public_profile",
+  "initiate_donation",
+  "manage_own_sessions",
+  "update_own_profile"
+] as const satisfies ReadonlyArray<UserPermission>;
+
+const creatorPermissions = [
+  ...fanPermissions,
+  "manage_own_challenges",
+  "view_own_donations",
+  "manage_own_submissions",
+  "manage_creator_profile"
+] as const satisfies ReadonlyArray<UserPermission>;
+
+const operatorPermissions = [
+  ...creatorPermissions,
+  "view_all_donations",
+  "view_audit_logs",
+  "manage_sessions",
+  "flag_content",
+  "resolve_support_cases"
+] as const satisfies ReadonlyArray<UserPermission>;
+
+const adminPermissions = [
+  ...operatorPermissions,
+  "manage_all_challenges",
+  "manage_roles",
+  "manage_payouts",
+  "manage_security_settings",
+  "manage_rate_limits"
+] as const satisfies ReadonlyArray<UserPermission>;
+
+export const rolePermissions: Record<UserRole, ReadonlyArray<UserPermission>> = {
+  fan: fanPermissions,
+  creator: creatorPermissions,
+  operator: operatorPermissions,
+  admin: adminPermissions
+};
+
+export const userStatusSchema = z.enum(["active", "disabled", "pending_verification"]);
+export type UserStatus = z.infer<typeof userStatusSchema>;
+
+export const userMetadataSchema = z
+  .object({
+    locale: z.string().optional(),
+    timezone: z.string().optional(),
+    notifications: z
+      .object({
+        email: z.boolean().optional(),
+        sms: z.boolean().optional(),
+        push: z.boolean().optional()
+      })
+      .optional(),
+    featureFlags: z.record(z.string(), z.boolean()).optional()
+  })
+  .optional();
+
+export const userSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  roles: z.array(userRoleSchema).min(1),
+  permissions: z.array(userPermissionSchema).min(1),
+  displayName: z.string(),
+  status: userStatusSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  metadata: userMetadataSchema
+});
+export type User = z.infer<typeof userSchema>;
+
+export const authFactorTypeSchema = z.enum(["email_otp", "magic_link"]);
+export type AuthFactorType = z.infer<typeof authFactorTypeSchema>;
+
+export const authFactorStatusSchema = z.enum(["active", "consumed", "expired", "revoked"]);
+export type AuthFactorStatus = z.infer<typeof authFactorStatusSchema>;
+
+export const authFactorSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  type: authFactorTypeSchema,
+  channel: z.enum(["email", "phone"]),
+  attempts: z.number().int().nonnegative().default(0),
+  expiresAt: z.string(),
+  createdAt: z.string(),
+  status: authFactorStatusSchema
+});
+export type AuthFactor = z.infer<typeof authFactorSchema>;
+
+export const sessionStatusSchema = z.enum(["active", "revoked", "expired"]);
+export type SessionStatus = z.infer<typeof sessionStatusSchema>;
+
+export const sessionSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  rolesSnapshot: z.array(userRoleSchema).min(1),
+  issuedAt: z.string(),
+  expiresAt: z.string(),
+  refreshTokenHash: z.string(),
+  ipAddress: z.string().ip({ version: "v4" }).or(z.string().ip({ version: "v6" })).optional(),
+  userAgent: z.string().optional(),
+  status: sessionStatusSchema,
+  metadata: z
+    .object({
+      device: z.string().optional(),
+      riskLevel: z.enum(["low", "medium", "high"]).optional()
+    })
+    .optional()
+});
+export type Session = z.infer<typeof sessionSchema>;
+
+export const auditLogSeveritySchema = z.enum(["info", "warning", "critical"]);
+export type AuditLogSeverity = z.infer<typeof auditLogSeveritySchema>;
+
+export const auditLogActionSchema = z.enum([
+  "auth.login",
+  "auth.logout",
+  "auth.factor.enroll",
+  "auth.factor.challenge",
+  "auth.factor.verify",
+  "auth.session.issue",
+  "auth.session.refresh",
+  "auth.session.revoke",
+  "security.settings.update",
+  "security.rate_limit.update"
+]);
+export type AuditLogAction = z.infer<typeof auditLogActionSchema>;
+
+export const auditLogEntrySchema = z.object({
+  id: z.string(),
+  actorId: z.string(),
+  actorRoles: z.array(userRoleSchema),
+  action: auditLogActionSchema,
+  targetId: z.string().optional(),
+  context: z
+    .object({
+      requestId: z.string().optional(),
+      ipAddress: z.string().optional(),
+      userAgent: z.string().optional(),
+      summary: z.string().optional()
+    })
+    .optional(),
+  severity: auditLogSeveritySchema,
+  createdAt: z.string()
+});
+export type AuditLogEntry = z.infer<typeof auditLogEntrySchema>;
+
+export const authBootstrapContractSchema = z.object({
+  roles: z.array(userRoleSchema),
+  permissions: z.array(userPermissionSchema),
+  rolePermissions: z.record(userRoleSchema, z.array(userPermissionSchema))
+});
+export type AuthBootstrapContract = z.infer<typeof authBootstrapContractSchema>;
+
+export const defaultAuthBootstrapContract: AuthBootstrapContract = {
+  roles: userRoleSchema.options,
+  permissions: userPermissionSchema.options,
+  rolePermissions: {
+    fan: [...fanPermissions],
+    creator: [...creatorPermissions],
+    operator: [...operatorPermissions],
+    admin: [...adminPermissions]
+  }
+};
+
+export const viewerSchema = z.object({
+  user: userSchema.nullable(),
+  session: sessionSchema.nullable()
+});
+export type Viewer = z.infer<typeof viewerSchema>;

--- a/packages/types/src/graphql-client.ts
+++ b/packages/types/src/graphql-client.ts
@@ -6,6 +6,8 @@ import {
 } from "./challenges";
 import type { ChallengeList } from "./challenges";
 import type { Challenge } from "./challenges";
+import { viewerSchema } from "./auth";
+import type { Viewer } from "./auth";
 
 export interface TrendPotGraphQLClientOptions {
   baseUrl: string;
@@ -198,6 +200,36 @@ const CHALLENGE_ADMIN_LIST_QUERY = /* GraphQL */ `
   }
 `;
 
+const viewerDataSchema = z.object({
+  viewer: viewerSchema
+});
+
+const VIEWER_QUERY = /* GraphQL */ `
+  query Viewer {
+    viewer {
+      user {
+        id
+        email
+        phone
+        displayName
+        roles
+        permissions
+        status
+        createdAt
+        updatedAt
+      }
+      session {
+        id
+        issuedAt
+        expiresAt
+        ipAddress
+        userAgent
+        status
+      }
+    }
+  }
+`;
+
 const updateChallengeDataSchema = z.object({
   updateChallenge: challengeSchema
 });
@@ -344,6 +376,13 @@ export class TrendPotGraphQLClient {
     });
   }
 
+  async getViewer(): Promise<Viewer> {
+    return this.executeGraphQL({
+      query: VIEWER_QUERY,
+      parser: (payload) => viewerDataSchema.parse(payload).viewer
+    });
+  }
+
   private prepareListVariables(params: ListChallengesParams) {
     const variables: Record<string, unknown> = {};
 
@@ -435,7 +474,7 @@ export class TrendPotGraphQLClient {
   }
 }
 
-export { FEATURED_CHALLENGES_QUERY };
+export { FEATURED_CHALLENGES_QUERY, VIEWER_QUERY };
 export {
   CHALLENGES_QUERY,
   CHALLENGE_QUERY,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./challenges";
 export * from "./leaderboard";
 export * from "./graphql-client";
+export * from "./auth";


### PR DESCRIPTION
## Summary
- extend the API GraphQL context to decode TrendPot auth headers, expose a viewer query, and surface user/session models
- add reusable authorization decorators, guards, and in-memory rate limiting with audit logging applied to challenge resolvers
- update shared auth Zod contracts, GraphQL client artifacts, and documentation/tracker notes for the viewer/session contract

## Testing
- `pnpm -w run lint` *(fails: corepack cannot download pnpm because upstream registry access is blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d566334c88832e8c12a9c94a448309