### PR TITLE
Refine verify messaging for TikTok-only login

### DIFF
--- a/apps/web/src/app/auth/verify/page.tsx
+++ b/apps/web/src/app/auth/verify/page.tsx
@@ -14,22 +14,11 @@ interface VerifyPageProps {
 export default function VerifyPage({ searchParams }: VerifyPageProps) {
   const email = typeof searchParams.email === "string" ? searchParams.email : undefined;
   const deliveryHint = typeof searchParams.deliveryHint === "string" ? searchParams.deliveryHint : undefined;
-  const displayName = typeof searchParams.displayName === "string" ? searchParams.displayName : undefined;
-  const intent = typeof searchParams.intent === "string" ? searchParams.intent : undefined;
   const nextPath = resolveNextPath(typeof searchParams.next === "string" ? searchParams.next : null);
-  const expiresAt = typeof searchParams.expiresAt === "string" ? searchParams.expiresAt : undefined;
 
   return (
     <section className="flex flex-col gap-10">
-      <VerifyForm
-        email={email ?? ""}
-        token=""
-        expiresAt={expiresAt}
-        deliveryHint={deliveryHint}
-        displayName={displayName}
-        intent={intent}
-        nextPath={nextPath ?? undefined}
-      />
+      <VerifyForm emailHint={deliveryHint ?? email} nextPath={nextPath ?? undefined} />
     </section>
   );
 }

--- a/apps/web/src/components/auth/verify-form.tsx
+++ b/apps/web/src/components/auth/verify-form.tsx
@@ -1,34 +1,63 @@
 "use client";
 
-import { Card, CardContent, CardHeader } from "@trendpot/ui";
+import { useMemo, useState } from "react";
+import { Button, Card, CardContent, CardFooter, CardHeader } from "@trendpot/ui";
 
 interface VerifyFormProps {
-  email: string;
-  token: string;
-  expiresAt?: string;
-  deliveryHint?: string;
-  displayName?: string;
-  intent?: string;
+  emailHint?: string;
   nextPath?: string;
 }
 
-export function VerifyForm({ email, deliveryHint }: VerifyFormProps) {
+function buildAuthUrl(basePath: "/login" | "/signup", nextPath?: string) {
+  if (!nextPath) {
+    return basePath;
+  }
+
+  const encodedNext = encodeURIComponent(nextPath);
+  return `${basePath}?next=${encodedNext}`;
+}
+
+export function VerifyForm({ emailHint, nextPath }: VerifyFormProps) {
+  const [isNavigating, setIsNavigating] = useState(false);
+  const loginHref = useMemo(() => buildAuthUrl("/login", nextPath), [nextPath]);
+  const signupHref = useMemo(() => buildAuthUrl("/signup", nextPath), [nextPath]);
+
   return (
     <Card className="relative mx-auto flex w-full max-w-lg flex-col overflow-hidden backdrop-blur">
       <CardHeader className="gap-3">
         <h2 className="text-xl font-semibold sm:text-2xl">TikTok login replaces email codes</h2>
         <p className="text-sm text-slate-400 sm:text-base">
-          We no longer issue one-time passcodes to <span className="font-medium text-slate-200">{deliveryHint ?? email}</span>.
-          Use the TikTok login entry point to authenticate instead. Once the OpenSDK completes, you'll be redirected back to the
-          page you started from.
+          We no longer issue one-time passcodes to
+          {" "}
+          <span className="font-medium text-slate-200">{emailHint ?? "your email"}</span>. Use the TikTok login entry point to
+          authenticate instead. Once the OpenSDK completes, you&apos;ll be redirected back to the page you started from.
         </p>
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
-          Looking for your account? Head to the <a href="/login" className="underline">login</a> or
-          <a href="/signup" className="underline"> signup</a> page and start the TikTok flow—no email code required.
+          Looking for your account? Start the TikTok flow from the login or signup pages—no email code required.
         </p>
       </CardContent>
+      <CardFooter className="sticky bottom-0 left-0 right-0 border-t border-slate-800 bg-slate-950/80 backdrop-blur-md md:static md:bg-transparent md:backdrop-blur-none">
+        <Button
+          type="button"
+          className="w-full"
+          onClick={() => {
+            setIsNavigating(true);
+            if (typeof window !== "undefined") {
+              window.location.href = loginHref;
+            } else {
+              setIsNavigating(false);
+            }
+          }}
+          disabled={isNavigating}
+        >
+          {isNavigating ? "Opening TikTok login…" : "Continue with TikTok"}
+        </Button>
+        <p className="text-xs text-slate-500 sm:text-sm">
+          Need to create an account? <a href={signupHref} className="text-emerald-400 underline">Sign up with TikTok</a>.
+        </p>
+      </CardFooter>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- update the legacy /auth/verify surface to funnel visitors into the TikTok login/signup flow with CTA buttons and next-path handling
- simplify verify page parameter parsing now that email OTP artifacts are gone
- refresh DEVELOPMENT_TRACKER with the new TikTok-only auth posture and outstanding security follow-ups

## Testing
- pnpm -w run lint *(fails: corepack could not download pnpm because outbound requests are blocked)*
- pnpm -w run typecheck *(fails: corepack could not download pnpm because outbound requests are blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d5acf9561c832ea6da8914176a6f2b