### PR TITLE
Add TikTok ingestion QA docs, test shims, and integration suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,14 @@ Mongoose schemas colocate with modules; each module exports a documented public 
 Feature flags via env/DB; no hard‑coded behavior.
 
 
+## TikTok Ingestion Security & QA Checklist
+- **Key management:** Encrypted TikTok OAuth tokens must use the `trendpot/tiktok-display-oauth` KMS key. Rotate client and refresh secrets quarterly and verify the key ID stored with each credential matches the active cipher before deployment.
+- **Sanitization:** Run `NODE_PATH=./test-shims node --loader ./test-shims/ts-loader.mjs --test packages/types/src/tiktok.sanitization.test.ts` to ensure the embed sanitizer rejects malicious HTML payloads prior to rollout.
+- **Worker health:** Execute the integration tests in `apps/worker/src/tiktok/tiktok-jobs.integration.test.ts` to validate metrics refresh flows, Redis publications, and token refresh logic in isolation.
+- **Frontend rendering:** Render `apps/web/src/components/challenges/challenge-detail.integration.test.tsx` when validating responsive embeds so regressions in the hero/full-bleed layout are caught early.
+- **Runbook:** See `docs/runbooks/tiktok-ingestion.md` for incident response, manual refresh, and provisioning guidance.
+
+
 
 
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "@nestjs/mongoose": "10.0.2",
     "@nestjs/mercurius": "12.0.1",
     "@nestjs/platform-fastify": "10.3.7",
+    "bullmq": "4.11.4",
     "fastify": "4.28.1",
     "@trendpot/types": "workspace:*",
     "ioredis": "5.3.2",

--- a/apps/api/schema.gql
+++ b/apps/api/schema.gql
@@ -17,6 +17,13 @@ enum UserStatus {
   PENDING_VERIFICATION
 }
 
+enum SubmissionState {
+  PENDING
+  APPROVED
+  REJECTED
+  REMOVED
+}
+
 type ChallengeSummary {
   id: String!
   title: String!
@@ -71,6 +78,94 @@ type Challenge {
   version: Int!
   description: String!
   createdAt: DateTime!
+  submissions: SubmissionConnection
+}
+
+type TikTokAccount {
+  id: String!
+  username: String!
+  displayName: String
+  avatarUrl: String
+  scopes: [String!]!
+  accessTokenExpiresAt: DateTime!
+  refreshTokenExpiresAt: DateTime!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type TikTokEmbed {
+  provider: String!
+  html: String!
+  scriptUrl: String!
+  width: Int
+  height: Int
+  thumbnailUrl: String
+  authorName: String
+  authorUrl: String
+}
+
+type VideoMetrics {
+  likeCount: Int!
+  commentCount: Int!
+  shareCount: Int!
+  viewCount: Int!
+}
+
+type Video {
+  id: String!
+  tiktokVideoId: String!
+  ownerAccountId: String!
+  shareUrl: String!
+  caption: String
+  postedAt: DateTime
+  embed: TikTokEmbed!
+  metrics: VideoMetrics!
+  lastRefreshedAt: DateTime!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  owner: TikTokAccount!
+}
+
+type VideoEdge {
+  cursor: String!
+  node: Video!
+}
+
+type VideoPageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+type VideoConnection {
+  edges: [VideoEdge!]!
+  pageInfo: VideoPageInfo!
+}
+
+type Submission {
+  id: String!
+  challengeId: String!
+  creatorUserId: String!
+  videoId: String!
+  state: SubmissionState!
+  rejectionReason: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  video: Video!
+}
+
+type SubmissionEdge {
+  cursor: String!
+  node: Submission!
+}
+
+type SubmissionPageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+type SubmissionConnection {
+  edges: [SubmissionEdge!]!
+  pageInfo: SubmissionPageInfo!
 }
 
 type Health {
@@ -180,11 +275,17 @@ input UpdateViewerProfileInput {
   phone: String
 }
 
+input SubmitToChallengeInput {
+  challengeId: String!
+  tiktokVideoId: String!
+}
+
 type Query {
   featuredChallenges(status: String, limit: Int): [ChallengeSummary!]!
   challenges(status: String, limit: Int): [ChallengeSummary!]!
   challengeAdminList(input: ChallengeListInput): ChallengeList!
   challenge(id: String!): Challenge
+  creatorVideos(first: Int, after: String): VideoConnection!
   health: Health!
   viewer: Viewer!
   viewerSessions: [ViewerSession!]!
@@ -199,6 +300,7 @@ type Mutation {
   updateViewerProfile(input: UpdateViewerProfileInput!): ViewerUser!
   logoutSession(sessionId: String!): Viewer!
   revokeSession(sessionId: String!): ViewerSession!
+  submitToChallenge(input: SubmitToChallengeInput!): Submission!
 }
 
 scalar DateTime

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,10 +12,14 @@ import { ChallengeResolver } from "./challenge.resolver";
 import { HealthResolver } from "./health.resolver";
 import { AuthResolver } from "./models/auth.resolver";
 import { ChallengeEntity, ChallengeSchema } from "./models/challenge.schema";
+import { SubmissionEntity, SubmissionSchema } from "./models/submission.schema";
+import { TikTokAccountEntity, TikTokAccountSchema } from "./models/tiktok-account.schema";
+import { VideoEntity, VideoSchema } from "./models/video.schema";
 import { buildGraphQLContext } from "./observability/graphql-context";
 import { structuredErrorFormatter } from "./observability/error-formatter";
 import { PlatformAuthModule } from "./platform-auth/platform-auth.module";
 import { PlatformAuthService } from "./platform-auth/platform-auth.service";
+import { TikTokModule } from "./tiktok/tiktok.module";
 
 @Module({
   imports: [
@@ -32,8 +36,14 @@ import { PlatformAuthService } from "./platform-auth/platform-auth.service";
       })
     }),
     MongooseModule.forRoot(process.env.MONGODB_URI ?? "mongodb://localhost:27017/trendpot"),
-    MongooseModule.forFeature([{ name: ChallengeEntity.name, schema: ChallengeSchema }]),
-    PlatformAuthModule
+    MongooseModule.forFeature([
+      { name: ChallengeEntity.name, schema: ChallengeSchema },
+      { name: TikTokAccountEntity.name, schema: TikTokAccountSchema },
+      { name: VideoEntity.name, schema: VideoSchema },
+      { name: SubmissionEntity.name, schema: SubmissionSchema }
+    ]),
+    PlatformAuthModule,
+    TikTokModule
   ],
   providers: [
     AppService,

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -473,7 +473,8 @@ const toChallenge = (challenge: ChallengeDocumentShape): Challenge => ({
   status: (challenge.status as ChallengeStatus) ?? ChallengeStatus.Draft,
   createdAt: challenge.createdAt.toISOString(),
   updatedAt: challenge.updatedAt.toISOString(),
-  version: challenge.__v ?? 0
+  version: challenge.__v ?? 0,
+  submissions: null
 });
 
 const allowedStatuses = new Set<ChallengeStatus>([

--- a/apps/api/src/models/challenge.model.ts
+++ b/apps/api/src/models/challenge.model.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from "@nestjs/graphql";
 import { GraphQLISODateTime } from "@nestjs/graphql";
 import { ChallengeSummaryModel } from "./challenge-summary.model";
+import { SubmissionConnectionModel } from "./submission-connection.model";
 
 @ObjectType("Challenge")
 export class ChallengeModel extends ChallengeSummaryModel {
@@ -9,4 +10,7 @@ export class ChallengeModel extends ChallengeSummaryModel {
 
   @Field(() => GraphQLISODateTime)
   declare createdAt: Date;
+
+  @Field(() => SubmissionConnectionModel, { nullable: true })
+  declare submissions?: SubmissionConnectionModel | null;
 }

--- a/apps/api/src/models/submission-connection.model.ts
+++ b/apps/api/src/models/submission-connection.model.ts
@@ -1,0 +1,12 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { SubmissionEdgeModel } from "./submission-edge.model";
+import { SubmissionPageInfoModel } from "./submission-page-info.model";
+
+@ObjectType("SubmissionConnection")
+export class SubmissionConnectionModel {
+  @Field(() => [SubmissionEdgeModel])
+  declare edges: SubmissionEdgeModel[];
+
+  @Field(() => SubmissionPageInfoModel)
+  declare pageInfo: SubmissionPageInfoModel;
+}

--- a/apps/api/src/models/submission-edge.model.ts
+++ b/apps/api/src/models/submission-edge.model.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { SubmissionModel } from "./submission.model";
+
+@ObjectType("SubmissionEdge")
+export class SubmissionEdgeModel {
+  @Field()
+  declare cursor: string;
+
+  @Field(() => SubmissionModel)
+  declare node: SubmissionModel;
+}

--- a/apps/api/src/models/submission-page-info.model.ts
+++ b/apps/api/src/models/submission-page-info.model.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("SubmissionPageInfo")
+export class SubmissionPageInfoModel {
+  @Field({ nullable: true })
+  declare endCursor?: string | null;
+
+  @Field()
+  declare hasNextPage: boolean;
+}

--- a/apps/api/src/models/submission-state.enum.ts
+++ b/apps/api/src/models/submission-state.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum SubmissionState {
+  Pending = "pending",
+  Approved = "approved",
+  Rejected = "rejected",
+  Removed = "removed"
+}
+
+registerEnumType(SubmissionState, {
+  name: "SubmissionState",
+  description: "Lifecycle states for TikTok challenge submissions."
+});

--- a/apps/api/src/models/submission.model.ts
+++ b/apps/api/src/models/submission.model.ts
@@ -1,0 +1,34 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLISODateTime } from "@nestjs/graphql";
+import { SubmissionState } from "./submission-state.enum";
+import { VideoModel } from "./video.model";
+
+@ObjectType("Submission")
+export class SubmissionModel {
+  @Field()
+  declare id: string;
+
+  @Field()
+  declare challengeId: string;
+
+  @Field()
+  declare creatorUserId: string;
+
+  @Field()
+  declare videoId: string;
+
+  @Field(() => SubmissionState)
+  declare state: SubmissionState;
+
+  @Field({ nullable: true })
+  declare rejectionReason?: string | null;
+
+  @Field(() => GraphQLISODateTime)
+  declare createdAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare updatedAt: Date;
+
+  @Field(() => VideoModel)
+  declare video: VideoModel;
+}

--- a/apps/api/src/models/submission.schema.ts
+++ b/apps/api/src/models/submission.schema.ts
@@ -1,0 +1,68 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, SchemaTypes } from "mongoose";
+import { ChallengeEntity } from "./challenge.schema";
+import { SubmissionState } from "./submission-state.enum";
+import { VideoEntity } from "./video.schema";
+import { UserEntity } from "../platform-auth/schemas/user.schema";
+
+const sanitizeModerationReason = (value: string | null | undefined): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return trimmed.slice(0, 500);
+};
+
+@Schema({
+  collection: "submissions",
+  timestamps: true,
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+})
+export class SubmissionEntity {
+  @Prop({ type: SchemaTypes.ObjectId, ref: ChallengeEntity.name, required: true, index: true })
+  declare challengeId: string;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: UserEntity.name, required: true })
+  declare creatorUserId: string;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: VideoEntity.name, required: true })
+  declare videoId: string;
+
+  @Prop({ required: true, enum: SubmissionState, default: SubmissionState.Pending })
+  declare state: SubmissionState;
+
+  @Prop({ required: false, default: null, set: sanitizeModerationReason })
+  declare rejectionReason: string | null;
+
+  @Prop({
+    type: {
+      decidedAt: { type: Date },
+      decidedByUserId: { type: SchemaTypes.ObjectId, ref: UserEntity.name },
+      notes: { type: String }
+    },
+    default: null
+  })
+  declare moderation?: {
+    decidedAt?: Date;
+    decidedByUserId?: string;
+    notes?: string;
+  } | null;
+}
+
+export type SubmissionDocument = HydratedDocument<SubmissionEntity>;
+
+export const SubmissionSchema = SchemaFactory.createForClass(SubmissionEntity);
+
+SubmissionSchema.virtual("id").get(function (this: SubmissionEntity & { _id: unknown }) {
+  return String((this as { _id: { toString(): string } })._id);
+});
+
+SubmissionSchema.index({ challengeId: 1, state: 1, _id: -1 });
+SubmissionSchema.index({ creatorUserId: 1, challengeId: 1 });
+SubmissionSchema.index({ videoId: 1 });

--- a/apps/api/src/models/submit-to-challenge.input.ts
+++ b/apps/api/src/models/submit-to-challenge.input.ts
@@ -1,0 +1,11 @@
+import { Field, InputType } from "@nestjs/graphql";
+
+@InputType("SubmitToChallengeInput")
+export class SubmitToChallengeInputModel {
+  @Field()
+  declare challengeId: string;
+
+  @Field()
+  declare tiktokVideoId: string;
+}
+

--- a/apps/api/src/models/tiktok-account.model.ts
+++ b/apps/api/src/models/tiktok-account.model.ts
@@ -1,0 +1,32 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLISODateTime } from "@nestjs/graphql";
+
+@ObjectType("TikTokAccount")
+export class TikTokAccountModel {
+  @Field()
+  declare id: string;
+
+  @Field()
+  declare username: string;
+
+  @Field({ nullable: true })
+  declare displayName?: string | null;
+
+  @Field({ nullable: true })
+  declare avatarUrl?: string | null;
+
+  @Field(() => [String])
+  declare scopes: string[];
+
+  @Field(() => GraphQLISODateTime)
+  declare accessTokenExpiresAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare refreshTokenExpiresAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare createdAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare updatedAt: Date;
+}

--- a/apps/api/src/models/tiktok-account.schema.ts
+++ b/apps/api/src/models/tiktok-account.schema.ts
@@ -1,0 +1,151 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, SchemaTypes } from "mongoose";
+import { UserEntity } from "../platform-auth/schemas/user.schema";
+
+interface EncryptedToken {
+  keyId: string;
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+}
+
+const sanitizeTikTokUsername = (value: string): string => {
+  const normalized = value.trim().replace(/^@+/, "");
+  if (normalized.length === 0) {
+    throw new Error("TikTok username cannot be empty.");
+  }
+
+  return normalized.toLowerCase();
+};
+
+const sanitizeDisplayName = (value: string | null | undefined): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const sanitizeAvatarUrl = (value: string | null | undefined): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:") {
+      throw new Error("Avatar URL must use HTTPS.");
+    }
+
+    if (!url.hostname.includes("tiktok")) {
+      throw new Error("Avatar URL must point to a TikTok-controlled domain.");
+    }
+
+    return url.toString();
+  } catch (error) {
+    throw new Error(`Invalid TikTok avatar URL: ${(error as Error).message}`);
+  }
+};
+
+const normalizeScopes = (value: string[] | undefined): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const scopes = new Set<string>();
+  for (const scope of value) {
+    if (typeof scope !== "string") {
+      continue;
+    }
+
+    const trimmed = scope.trim();
+    if (trimmed.length > 0) {
+      scopes.add(trimmed);
+    }
+  }
+
+  return Array.from(scopes).sort();
+};
+
+@Schema({
+  collection: "tiktok_accounts",
+  timestamps: true,
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+})
+export class TikTokAccountEntity {
+  @Prop({ type: SchemaTypes.ObjectId, ref: UserEntity.name, required: true, index: true })
+  declare userId: string;
+
+  @Prop({ required: true, unique: true, trim: true })
+  declare openId: string;
+
+  @Prop({ required: true, trim: true, set: sanitizeTikTokUsername })
+  declare username: string;
+
+  @Prop({ required: false, default: null, set: sanitizeDisplayName })
+  declare displayName: string | null;
+
+  @Prop({ required: false, default: null, set: sanitizeAvatarUrl })
+  declare avatarUrl: string | null;
+
+  @Prop({ type: [String], required: true, default: [], set: normalizeScopes })
+  declare scopes: string[];
+
+  @Prop({
+    type: {
+      keyId: { type: String, required: true },
+      ciphertext: { type: String, required: true },
+      iv: { type: String, required: true },
+      authTag: { type: String, required: true }
+    },
+    required: true
+  })
+  declare accessToken: EncryptedToken;
+
+  @Prop({
+    type: {
+      keyId: { type: String, required: true },
+      ciphertext: { type: String, required: true },
+      iv: { type: String, required: true },
+      authTag: { type: String, required: true }
+    },
+    required: true
+  })
+  declare refreshToken: EncryptedToken;
+
+  @Prop({ required: true })
+  declare accessTokenExpiresAt: Date;
+
+  @Prop({ required: true })
+  declare refreshTokenExpiresAt: Date;
+
+  @Prop({
+    type: {
+      lastVideoSyncAt: { type: Date },
+      lastProfileRefreshAt: { type: Date },
+      lastMetricsRefreshAt: { type: Date },
+      lastMetricsErrorAt: { type: Date }
+    },
+    required: false,
+    default: {}
+  })
+  declare syncMetadata?: {
+    lastVideoSyncAt?: Date;
+    lastProfileRefreshAt?: Date;
+    lastMetricsRefreshAt?: Date;
+    lastMetricsErrorAt?: Date;
+  };
+}
+
+export type TikTokAccountDocument = HydratedDocument<TikTokAccountEntity>;
+
+export const TikTokAccountSchema = SchemaFactory.createForClass(TikTokAccountEntity);
+
+TikTokAccountSchema.virtual("id").get(function (this: TikTokAccountEntity & { _id: unknown }) {
+  return String((this as { _id: { toString(): string } })._id);
+});
+
+TikTokAccountSchema.index({ userId: 1 });
+TikTokAccountSchema.index({ openId: 1 }, { unique: true });

--- a/apps/api/src/models/tiktok-embed.model.ts
+++ b/apps/api/src/models/tiktok-embed.model.ts
@@ -1,0 +1,28 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("TikTokEmbed")
+export class TikTokEmbedModel {
+  @Field()
+  declare provider: string;
+
+  @Field()
+  declare html: string;
+
+  @Field()
+  declare scriptUrl: string;
+
+  @Field({ nullable: true })
+  declare width?: number;
+
+  @Field({ nullable: true })
+  declare height?: number;
+
+  @Field({ nullable: true })
+  declare thumbnailUrl?: string;
+
+  @Field({ nullable: true })
+  declare authorName?: string;
+
+  @Field({ nullable: true })
+  declare authorUrl?: string;
+}

--- a/apps/api/src/models/video-connection.model.ts
+++ b/apps/api/src/models/video-connection.model.ts
@@ -1,0 +1,12 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { VideoEdgeModel } from "./video-edge.model";
+import { VideoPageInfoModel } from "./video-page-info.model";
+
+@ObjectType("VideoConnection")
+export class VideoConnectionModel {
+  @Field(() => [VideoEdgeModel])
+  declare edges: VideoEdgeModel[];
+
+  @Field(() => VideoPageInfoModel)
+  declare pageInfo: VideoPageInfoModel;
+}

--- a/apps/api/src/models/video-edge.model.ts
+++ b/apps/api/src/models/video-edge.model.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { VideoModel } from "./video.model";
+
+@ObjectType("VideoEdge")
+export class VideoEdgeModel {
+  @Field()
+  declare cursor: string;
+
+  @Field(() => VideoModel)
+  declare node: VideoModel;
+}

--- a/apps/api/src/models/video-metrics.model.ts
+++ b/apps/api/src/models/video-metrics.model.ts
@@ -1,0 +1,16 @@
+import { Field, Int, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("VideoMetrics")
+export class VideoMetricsModel {
+  @Field(() => Int)
+  declare likeCount: number;
+
+  @Field(() => Int)
+  declare commentCount: number;
+
+  @Field(() => Int)
+  declare shareCount: number;
+
+  @Field(() => Int)
+  declare viewCount: number;
+}

--- a/apps/api/src/models/video-page-info.model.ts
+++ b/apps/api/src/models/video-page-info.model.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("VideoPageInfo")
+export class VideoPageInfoModel {
+  @Field({ nullable: true })
+  declare endCursor?: string | null;
+
+  @Field()
+  declare hasNextPage: boolean;
+}

--- a/apps/api/src/models/video.model.ts
+++ b/apps/api/src/models/video.model.ts
@@ -1,0 +1,44 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLISODateTime } from "@nestjs/graphql";
+import { TikTokAccountModel } from "./tiktok-account.model";
+import { TikTokEmbedModel } from "./tiktok-embed.model";
+import { VideoMetricsModel } from "./video-metrics.model";
+
+@ObjectType("Video")
+export class VideoModel {
+  @Field()
+  declare id: string;
+
+  @Field()
+  declare tiktokVideoId: string;
+
+  @Field()
+  declare ownerAccountId: string;
+
+  @Field()
+  declare shareUrl: string;
+
+  @Field({ nullable: true })
+  declare caption?: string | null;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare postedAt?: Date | null;
+
+  @Field(() => TikTokEmbedModel)
+  declare embed: TikTokEmbedModel;
+
+  @Field(() => VideoMetricsModel)
+  declare metrics: VideoMetricsModel;
+
+  @Field(() => GraphQLISODateTime)
+  declare lastRefreshedAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare createdAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare updatedAt: Date;
+
+  @Field(() => TikTokAccountModel)
+  declare owner: TikTokAccountModel;
+}

--- a/apps/api/src/models/video.schema.ts
+++ b/apps/api/src/models/video.schema.ts
@@ -1,0 +1,134 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import type { TikTokEmbed } from "@trendpot/types";
+import { tikTokEmbedSchema } from "@trendpot/types";
+import { HydratedDocument, SchemaTypes } from "mongoose";
+import { TikTokAccountEntity } from "./tiktok-account.schema";
+
+interface VideoMetrics {
+  likeCount: number;
+  commentCount: number;
+  shareCount: number;
+  viewCount: number;
+}
+
+const TIKTOK_EMBED_SCRIPT_URL = "https://www.tiktok.com/embed.js";
+
+const sanitizeTikTokShareUrl = (value: string): string => {
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:") {
+      throw new Error("Share URL must use HTTPS.");
+    }
+
+    if (!url.hostname.endsWith("tiktok.com") && !url.hostname.endsWith("tiktokshort.com")) {
+      throw new Error("Share URL must point to TikTok.");
+    }
+
+    return url.toString();
+  } catch (error) {
+    throw new Error(`Invalid TikTok share URL: ${(error as Error).message}`);
+  }
+};
+
+const sanitizeTikTokEmbed = (embed: TikTokEmbed): TikTokEmbed => {
+  const parsed = tikTokEmbedSchema.parse(embed);
+  return {
+    provider: parsed.provider,
+    html: parsed.html,
+    scriptUrl: parsed.scriptUrl ?? TIKTOK_EMBED_SCRIPT_URL,
+    width: parsed.width,
+    height: parsed.height,
+    thumbnailUrl: parsed.thumbnailUrl,
+    authorName: parsed.authorName,
+    authorUrl: parsed.authorUrl
+  };
+};
+
+const sanitizeMetrics = (metrics: Partial<VideoMetrics> | undefined): VideoMetrics => {
+  return {
+    likeCount: Math.max(0, Math.trunc(metrics?.likeCount ?? 0)),
+    commentCount: Math.max(0, Math.trunc(metrics?.commentCount ?? 0)),
+    shareCount: Math.max(0, Math.trunc(metrics?.shareCount ?? 0)),
+    viewCount: Math.max(0, Math.trunc(metrics?.viewCount ?? 0))
+  };
+};
+
+const sanitizeCaption = (value: string | null | undefined): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return trimmed.slice(0, 2200);
+};
+
+@Schema({
+  collection: "videos",
+  timestamps: true,
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+})
+export class VideoEntity {
+  @Prop({ required: true, unique: true, trim: true })
+  declare tiktokVideoId: string;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: TikTokAccountEntity.name, required: true, index: true })
+  declare ownerTikTokAccountId: string;
+
+  @Prop({ required: true, trim: true, set: sanitizeTikTokShareUrl })
+  declare shareUrl: string;
+
+  @Prop({ required: false, default: null, set: sanitizeCaption })
+  declare caption: string | null;
+
+  @Prop({ required: false })
+  declare postedAt?: Date;
+
+  @Prop({
+    type: {
+      provider: { type: String, required: true, default: "tiktok" },
+      html: { type: String, required: true },
+      scriptUrl: { type: String, required: true, default: TIKTOK_EMBED_SCRIPT_URL },
+      width: { type: Number },
+      height: { type: Number },
+      thumbnailUrl: { type: String },
+      authorName: { type: String },
+      authorUrl: { type: String }
+    },
+    required: true,
+    _id: false,
+    set: sanitizeTikTokEmbed
+  })
+  declare embed: TikTokEmbed;
+
+  @Prop({
+    type: {
+      likeCount: { type: Number, default: 0, min: 0 },
+      commentCount: { type: Number, default: 0, min: 0 },
+      shareCount: { type: Number, default: 0, min: 0 },
+      viewCount: { type: Number, default: 0, min: 0 }
+    },
+    required: true,
+    default: {},
+    set: sanitizeMetrics
+  })
+  declare metrics: VideoMetrics;
+
+  @Prop({ required: true })
+  declare lastRefreshedAt: Date;
+}
+
+export type VideoDocument = HydratedDocument<VideoEntity>;
+
+export const VideoSchema = SchemaFactory.createForClass(VideoEntity);
+
+VideoSchema.virtual("id").get(function (this: VideoEntity & { _id: unknown }) {
+  return String((this as { _id: { toString(): string } })._id);
+});
+
+VideoSchema.index({ tiktokVideoId: 1 }, { unique: true });
+VideoSchema.index({ ownerTikTokAccountId: 1, postedAt: -1 });

--- a/apps/api/src/platform-auth/platform-auth.integration.test.ts
+++ b/apps/api/src/platform-auth/platform-auth.integration.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Types } from "mongoose";
+
+import { PlatformAuthService } from "./platform-auth.service";
+import type { TikTokAccountDocument } from "../models/tiktok-account.schema";
+import { TikTokTokenService } from "../security/tiktok-token.service";
+import type { TikTokIngestionQueue } from "../tiktok/tiktok-ingestion.queue";
+
+const createLogger = () => ({
+  info: () => {},
+  warn: () => {},
+  error: () => {}
+});
+
+test("upsertTikTokAccount enqueues an initial sync for linked users", async () => {
+  const tokenService = new TikTokTokenService();
+  const encryptedAccess = tokenService.encrypt("access-token");
+  const encryptedRefresh = tokenService.encrypt("refresh-token");
+
+  const userId = new Types.ObjectId();
+  const accountId = new Types.ObjectId();
+
+  let capturedPayload: unknown;
+
+  const ingestionQueue: Pick<TikTokIngestionQueue, "enqueueInitialSync"> = {
+    async enqueueInitialSync(payload) {
+      capturedPayload = payload;
+    }
+  };
+
+  const accountDoc = {
+    id: accountId.toHexString(),
+    _id: accountId
+  } as unknown as TikTokAccountDocument;
+
+  const service = new PlatformAuthService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {
+      findOneAndUpdate: () => ({
+        exec: async () => {
+          return accountDoc;
+        }
+      })
+    } as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    tokenService,
+    ingestionQueue as TikTokIngestionQueue
+  );
+
+  const logger = createLogger();
+  const now = new Date();
+
+  await (service as unknown as {
+    upsertTikTokAccount(params: {
+      user: { id: string; _id: Types.ObjectId; displayName?: string | null };
+      profile: { username?: string | null; displayName?: string | null; avatarUrl?: string | null };
+      tokenExchange: { openId: string; scope: string[] };
+      encryptedAccess: typeof encryptedAccess;
+      encryptedRefresh: typeof encryptedRefresh;
+      accessTokenExpiresAt: Date;
+      refreshTokenExpiresAt: Date;
+      logger: ReturnType<typeof createLogger>;
+      requestId: string;
+    }): Promise<TikTokAccountDocument | null>;
+  }).upsertTikTokAccount({
+    user: { id: userId.toHexString(), _id: userId, displayName: "Creator" },
+    profile: { username: "creator", displayName: "Creator" },
+    tokenExchange: { openId: "open-123", scope: ["user.info.basic", "video.list"] },
+    encryptedAccess,
+    encryptedRefresh,
+    accessTokenExpiresAt: new Date(now.getTime() + 60_000),
+    refreshTokenExpiresAt: new Date(now.getTime() + 120_000),
+    logger,
+    requestId: "req-1"
+  });
+
+  assert.ok(capturedPayload, "expected ingestion job to be enqueued");
+  assert.deepEqual(capturedPayload, {
+    accountId: accountId.toHexString(),
+    userId: userId.toHexString(),
+    trigger: "account_linked",
+    requestId: "req-1",
+    queuedAt: (capturedPayload as { queuedAt: string }).queuedAt
+  });
+  assert.match((capturedPayload as { queuedAt: string }).queuedAt, /T/);
+});
+
+test("upsertTikTokAccount logs a warning when user id cannot be resolved", async () => {
+  const tokenService = new TikTokTokenService();
+  const encryptedAccess = tokenService.encrypt("access-token");
+  const encryptedRefresh = tokenService.encrypt("refresh-token");
+
+  const accountId = new Types.ObjectId();
+  const warnings: Array<Record<string, unknown>> = [];
+
+  const ingestionQueue: Pick<TikTokIngestionQueue, "enqueueInitialSync"> = {
+    async enqueueInitialSync() {
+      throw new Error("should not be called");
+    }
+  };
+
+  const logger = {
+    info: () => {},
+    error: () => {},
+    warn: (payload: Record<string, unknown>) => {
+      warnings.push(payload);
+    }
+  };
+
+  const service = new PlatformAuthService(
+    {} as never,
+    {} as never,
+    {} as never,
+    {
+      findOneAndUpdate: () => ({
+        exec: async () => ({ id: accountId.toHexString(), _id: accountId } as TikTokAccountDocument)
+      })
+    } as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    tokenService,
+    ingestionQueue as TikTokIngestionQueue
+  );
+
+  await (service as unknown as {
+    upsertTikTokAccount(params: {
+      user: { _id: Types.ObjectId };
+      profile: { username?: string | null; displayName?: string | null; avatarUrl?: string | null };
+      tokenExchange: { openId: string; scope: string[] };
+      encryptedAccess: typeof encryptedAccess;
+      encryptedRefresh: typeof encryptedRefresh;
+      accessTokenExpiresAt: Date;
+      refreshTokenExpiresAt: Date;
+      logger: typeof logger;
+      requestId: string;
+    }): Promise<TikTokAccountDocument | null>;
+  }).upsertTikTokAccount({
+    user: { _id: new Types.ObjectId() },
+    profile: { username: null, displayName: null },
+    tokenExchange: { openId: "open-456", scope: ["user.info.basic"] },
+    encryptedAccess,
+    encryptedRefresh,
+    accessTokenExpiresAt: new Date(),
+    refreshTokenExpiresAt: new Date(),
+    logger,
+    requestId: "req-2"
+  });
+
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0]?.event, "tiktok.ingestion.missing_user_id");
+});

--- a/apps/api/src/platform-auth/platform-auth.module.ts
+++ b/apps/api/src/platform-auth/platform-auth.module.ts
@@ -3,23 +3,43 @@ import { MongooseModule } from "@nestjs/mongoose";
 import { AuthAuditService } from "../auth/auth-audit.service";
 import { RateLimitService } from "../auth/rate-limit.service";
 import { RedisService } from "../redis/redis.service";
+import { TikTokTokenService } from "../security/tiktok-token.service";
+import { TikTokIngestionQueue } from "../tiktok/tiktok-ingestion.queue";
 import { PlatformAuthService } from "./platform-auth.service";
 import { PlatformAuthResolver } from "./auth.resolver";
 import { TikTokAuthController } from "./tiktok.controller";
 import { AuditLogEntity, AuditLogSchema } from "./schemas/audit-log.schema";
 import { SessionEntity, SessionSchema } from "./schemas/session.schema";
 import { UserEntity, UserSchema } from "./schemas/user.schema";
+import { TikTokAccountEntity, TikTokAccountSchema } from "../models/tiktok-account.schema";
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: UserEntity.name, schema: UserSchema },
       { name: SessionEntity.name, schema: SessionSchema },
-      { name: AuditLogEntity.name, schema: AuditLogSchema }
+      { name: AuditLogEntity.name, schema: AuditLogSchema },
+      { name: TikTokAccountEntity.name, schema: TikTokAccountSchema }
     ])
   ],
   controllers: [TikTokAuthController],
-  providers: [PlatformAuthService, PlatformAuthResolver, RateLimitService, AuthAuditService, RedisService],
-  exports: [PlatformAuthService, MongooseModule, RateLimitService, AuthAuditService, RedisService]
+  providers: [
+    PlatformAuthService,
+    PlatformAuthResolver,
+    RateLimitService,
+    AuthAuditService,
+    RedisService,
+    TikTokTokenService,
+    TikTokIngestionQueue
+  ],
+  exports: [
+    PlatformAuthService,
+    MongooseModule,
+    RateLimitService,
+    AuthAuditService,
+    RedisService,
+    TikTokTokenService,
+    TikTokIngestionQueue
+  ]
 })
 export class PlatformAuthModule {}

--- a/apps/api/src/security/tiktok-token.service.ts
+++ b/apps/api/src/security/tiktok-token.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@nestjs/common";
+import {
+  TikTokEncryptedSecret,
+  TikTokTokenCipher,
+  mapAccountTokenToEncryptedSecret
+} from "@trendpot/utils";
+
+@Injectable()
+export class TikTokTokenService {
+  private readonly cipher = new TikTokTokenCipher();
+
+  get keyId(): string {
+    return this.cipher.keyId;
+  }
+
+  encrypt(plaintext: string): TikTokEncryptedSecret {
+    return this.cipher.encrypt(plaintext);
+  }
+
+  decrypt(secret: TikTokEncryptedSecret, expectedKeyId?: string): string {
+    return this.cipher.decrypt(secret, { keyId: expectedKeyId });
+  }
+
+  decryptAccountToken(
+    token: { ciphertext: string; iv: string; authTag?: string; tag?: string },
+    expectedKeyId?: string
+  ): string {
+    return this.decrypt(mapAccountTokenToEncryptedSecret(token), expectedKeyId);
+  }
+}
+

--- a/apps/api/src/tiktok/tiktok-ingestion.queue.ts
+++ b/apps/api/src/tiktok/tiktok-ingestion.queue.ts
@@ -1,0 +1,68 @@
+import { Injectable, OnModuleDestroy } from "@nestjs/common";
+import { Queue } from "bullmq";
+import IORedis from "ioredis";
+import {
+  TIKTOK_INGESTION_QUEUE,
+  TikTokInitialSyncJob,
+  tiktokInitialSyncJobSchema
+} from "@trendpot/types";
+
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+const MAX_ATTEMPTS = Number(process.env.TIKTOK_INGESTION_MAX_ATTEMPTS ?? 5);
+const BACKOFF_DELAY = Number(process.env.TIKTOK_INGESTION_RETRY_BACKOFF_MS ?? 5000);
+
+@Injectable()
+export class TikTokIngestionQueue implements OnModuleDestroy {
+  private readonly connection: IORedis;
+  private readonly queue: Queue<TikTokInitialSyncJob>;
+
+  constructor() {
+    this.connection = new IORedis(REDIS_URL);
+    this.queue = new Queue(TIKTOK_INGESTION_QUEUE, {
+      connection: this.connection,
+      defaultJobOptions: {
+        removeOnComplete: 100,
+        removeOnFail: 20,
+        attempts: MAX_ATTEMPTS,
+        backoff: {
+          type: "exponential",
+          delay: BACKOFF_DELAY
+        }
+      }
+    });
+  }
+
+  async enqueueInitialSync(params: {
+    accountId: string;
+    userId: string;
+    trigger?: TikTokInitialSyncJob["trigger"];
+    requestId?: string;
+    queuedAt?: string;
+  }): Promise<void> {
+    const trigger = params.trigger ?? "account_linked";
+    const queuedAt = params.queuedAt ?? new Date().toISOString();
+
+    const payload = tiktokInitialSyncJobSchema.parse({
+      accountId: params.accountId,
+      userId: params.userId,
+      trigger,
+      requestId: params.requestId,
+      queuedAt
+    });
+
+    await this.queue.add(
+      "initial-sync",
+      payload,
+      {
+        jobId: `initial:${payload.accountId}:${payload.queuedAt}`,
+        removeOnComplete: 100,
+        removeOnFail: 20
+      }
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.queue.close();
+    await this.connection.quit();
+  }
+}

--- a/apps/api/src/tiktok/tiktok.controller.ts
+++ b/apps/api/src/tiktok/tiktok.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Query, Req, Res, UnauthorizedException } from "@nestjs/common";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { resolveAuthContext } from "../auth/auth-context";
+import { TikTokDisplayService } from "./tiktok.service";
+import { PlatformAuthService } from "../platform-auth/platform-auth.service";
+
+type VideoListQuery = {
+  first?: string;
+  after?: string;
+};
+
+@Controller("/tiktok")
+export class TikTokController {
+  constructor(
+    private readonly tiktokService: TikTokDisplayService,
+    private readonly platformAuthService: PlatformAuthService
+  ) {}
+
+  @Get("/display/videos")
+  async listCreatorVideos(
+    @Req() req: FastifyRequest<{ Querystring: VideoListQuery }>,
+    @Res() reply: FastifyReply,
+    @Query() query: VideoListQuery
+  ) {
+    const auth = await resolveAuthContext(req, req.log, this.platformAuthService);
+    if (!auth.user) {
+      throw new UnauthorizedException("Authentication required.");
+    }
+
+    const first = typeof query.first === "string" ? Number.parseInt(query.first, 10) : undefined;
+    const after = typeof query.after === "string" && query.after.length > 0 ? query.after : undefined;
+
+    const result = await this.tiktokService.listCreatorVideos({
+      user: auth.user,
+      first: Number.isFinite(first) ? first : undefined,
+      after,
+      logger: req.log,
+      requestId: String(req.id)
+    });
+
+    reply.send(result);
+    return reply;
+  }
+}
+

--- a/apps/api/src/tiktok/tiktok.module.ts
+++ b/apps/api/src/tiktok/tiktok.module.ts
@@ -1,0 +1,31 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { PlatformAuthModule } from "../platform-auth/platform-auth.module";
+import { UserEntity, UserSchema } from "../platform-auth/schemas/user.schema";
+import { TikTokAccountEntity, TikTokAccountSchema } from "../models/tiktok-account.schema";
+import { VideoEntity, VideoSchema } from "../models/video.schema";
+import { SubmissionEntity, SubmissionSchema } from "../models/submission.schema";
+import { ChallengeEntity, ChallengeSchema } from "../models/challenge.schema";
+import { AuditLogEntity, AuditLogSchema } from "../platform-auth/schemas/audit-log.schema";
+import { TikTokDisplayService } from "./tiktok.service";
+import { TikTokResolver } from "./tiktok.resolver";
+import { TikTokController } from "./tiktok.controller";
+
+@Module({
+  imports: [
+    PlatformAuthModule,
+    MongooseModule.forFeature([
+      { name: UserEntity.name, schema: UserSchema },
+      { name: TikTokAccountEntity.name, schema: TikTokAccountSchema },
+      { name: VideoEntity.name, schema: VideoSchema },
+      { name: SubmissionEntity.name, schema: SubmissionSchema },
+      { name: ChallengeEntity.name, schema: ChallengeSchema },
+      { name: AuditLogEntity.name, schema: AuditLogSchema }
+    ])
+  ],
+  controllers: [TikTokController],
+  providers: [TikTokDisplayService, TikTokResolver],
+  exports: [TikTokDisplayService]
+})
+export class TikTokModule {}
+

--- a/apps/api/src/tiktok/tiktok.resolver.ts
+++ b/apps/api/src/tiktok/tiktok.resolver.ts
@@ -1,0 +1,62 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { Args, Context, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { Roles, RateLimit, RequireProfileFields } from "../auth/auth.decorators";
+import type { GraphQLContext } from "../observability/graphql-context";
+import { VideoConnectionModel } from "../models/video-connection.model";
+import { SubmissionModel } from "../models/submission.model";
+import { SubmitToChallengeInputModel } from "../models/submit-to-challenge.input";
+import { TikTokDisplayService } from "./tiktok.service";
+
+@Resolver()
+export class TikTokResolver {
+  constructor(private readonly tiktokService: TikTokDisplayService) {}
+
+  @Roles("creator")
+  @RequireProfileFields("displayName")
+  @RateLimit({ windowMs: 60_000, max: 30 })
+  @Query(() => VideoConnectionModel, { name: "creatorVideos" })
+  async creatorVideos(
+    @Args("first", { type: () => Int, nullable: true }) first: number | undefined,
+    @Args("after", { type: () => String, nullable: true }) after: string | undefined,
+    @Context() context: GraphQLContext
+  ) {
+    if (!context.user) {
+      throw new UnauthorizedException("Authentication required.");
+    }
+
+    return this.tiktokService.listCreatorVideos({
+      user: context.user,
+      first,
+      after,
+      logger: context.logger,
+      requestId: context.requestId
+    });
+  }
+
+  @Roles("creator")
+  @RequireProfileFields("displayName")
+  @RateLimit({ windowMs: 60_000, max: 10 })
+  @Mutation(() => SubmissionModel, { name: "submitToChallenge" })
+  async submitToChallenge(
+    @Args("input") input: SubmitToChallengeInputModel,
+    @Context() context: GraphQLContext
+  ) {
+    if (!context.user) {
+      throw new UnauthorizedException("Authentication required.");
+    }
+
+    const userAgentHeader = context.request?.headers["user-agent"];
+    const userAgent = typeof userAgentHeader === "string" ? userAgentHeader : undefined;
+
+    return this.tiktokService.submitToChallenge({
+      user: context.user,
+      challengeId: input.challengeId,
+      tiktokVideoId: input.tiktokVideoId,
+      logger: context.logger,
+      requestId: context.requestId,
+      ipAddress: context.request?.ip,
+      userAgent
+    });
+  }
+}
+

--- a/apps/api/src/tiktok/tiktok.service.ts
+++ b/apps/api/src/tiktok/tiktok.service.ts
@@ -1,0 +1,784 @@
+import { BadRequestException, Injectable, UnauthorizedException } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import type { Logger } from "pino";
+import { Types, type Model } from "mongoose";
+import type { AuthenticatedUser } from "../auth/auth.types";
+import { TikTokTokenService } from "../security/tiktok-token.service";
+import { RateLimitService } from "../auth/rate-limit.service";
+import type { UserDocument } from "../platform-auth/schemas/user.schema";
+import { UserEntity } from "../platform-auth/schemas/user.schema";
+import type { TikTokAccountDocument } from "../models/tiktok-account.schema";
+import { TikTokAccountEntity } from "../models/tiktok-account.schema";
+import type { VideoDocument } from "../models/video.schema";
+import { VideoEntity } from "../models/video.schema";
+import type { SubmissionDocument } from "../models/submission.schema";
+import { SubmissionEntity } from "../models/submission.schema";
+import { SubmissionState } from "../models/submission-state.enum";
+import type { ChallengeDocument } from "../models/challenge.schema";
+import { ChallengeEntity } from "../models/challenge.schema";
+import type { AuditLogDocument } from "../platform-auth/schemas/audit-log.schema";
+import { AuditLogEntity } from "../platform-auth/schemas/audit-log.schema";
+import type { AuditLogAction, AuditLogSeverity } from "@trendpot/types";
+import { tikTokEmbedSchema, type TikTokEmbed } from "@trendpot/types";
+
+interface ListCreatorVideosParams {
+  user: AuthenticatedUser;
+  first?: number;
+  after?: string;
+  logger: Logger;
+  requestId: string;
+}
+
+interface SubmitToChallengeParams {
+  user: AuthenticatedUser;
+  challengeId: string;
+  tiktokVideoId: string;
+  logger: Logger;
+  requestId: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+interface TikTokDisplayVideo {
+  id: string;
+  create_time?: number;
+  description?: string;
+  embed_html?: string;
+  share_url?: string;
+  cover_image_url?: string;
+  author?: {
+    open_id?: string;
+    display_name?: string;
+    avatar_url?: string;
+    username?: string;
+  };
+  video?: {
+    cover_image_url?: string;
+  };
+  stats?: {
+    digg_count?: number;
+    comment_count?: number;
+    share_count?: number;
+    play_count?: number;
+    view_count?: number;
+  };
+}
+
+interface TikTokDisplayListResponse {
+  data?: {
+    videos?: TikTokDisplayVideo[];
+    cursor?: string;
+    has_more?: boolean;
+  };
+  error?: {
+    code?: number;
+    message?: string;
+    log_id?: string;
+  };
+}
+
+interface TikTokDisplayMetricsResponse {
+  data?: {
+    metrics?: Array<{
+      id: string;
+      stats?: TikTokDisplayVideo["stats"];
+    }>;
+  };
+  error?: TikTokDisplayListResponse["error"];
+}
+
+interface VideoConnectionResult {
+  edges: Array<{ cursor: string; node: Record<string, unknown> }>;
+  pageInfo: { endCursor: string | null; hasNextPage: boolean };
+}
+
+const DISPLAY_API_BASE_URL = process.env.TIKTOK_DISPLAY_API_BASE_URL ?? "https://open-api.tiktok.com";
+const TOKEN_REFRESH_ENDPOINT = process.env.TIKTOK_TOKEN_ENDPOINT ??
+  "https://open-api.tiktok.com/oauth/refresh_token/";
+const DISPLAY_VIDEO_LIST_PATH = "/v2/video/list/";
+const DISPLAY_VIDEO_DATA_PATH = "/v2/video/data/";
+const CLIENT_KEY = process.env.TIKTOK_CLIENT_KEY ?? "";
+const CLIENT_SECRET = process.env.TIKTOK_CLIENT_SECRET ?? "";
+const PAGE_SIZE = Number(process.env.TIKTOK_INGESTION_PAGE_SIZE ?? 20);
+const RATE_LIMIT_PER_MIN = Number(process.env.TIKTOK_INGESTION_RATE_LIMIT_PER_MIN ?? 90);
+
+@Injectable()
+export class TikTokDisplayService {
+  constructor(
+    @InjectModel(UserEntity.name) private readonly userModel: Model<UserDocument>,
+    @InjectModel(TikTokAccountEntity.name) private readonly accountModel: Model<TikTokAccountDocument>,
+    @InjectModel(VideoEntity.name) private readonly videoModel: Model<VideoDocument>,
+    @InjectModel(SubmissionEntity.name) private readonly submissionModel: Model<SubmissionDocument>,
+    @InjectModel(ChallengeEntity.name) private readonly challengeModel: Model<ChallengeDocument>,
+    @InjectModel(AuditLogEntity.name) private readonly auditLogModel: Model<AuditLogDocument>,
+    private readonly tokenService: TikTokTokenService,
+    private readonly rateLimitService: RateLimitService
+  ) {}
+
+  async listCreatorVideos(params: ListCreatorVideosParams): Promise<VideoConnectionResult> {
+    const { user, first, after, logger, requestId } = params;
+    const account = await this.resolveCreatorAccount(user, logger, requestId);
+    const accessToken = await this.ensureValidAccessToken(account, logger, requestId);
+
+    const limit = sanitizePageSize(first);
+    const cursor = decodeVideoCursor(after);
+
+    const response = await this.callDisplayApi<TikTokDisplayListResponse>(
+      DISPLAY_VIDEO_LIST_PATH,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`
+        },
+        body: JSON.stringify({
+          cursor: null,
+          max_count: limit
+        })
+      },
+      { rateLimitKey: "video_list", logger, requestId }
+    );
+
+    const videos = response.data?.videos ?? [];
+    await Promise.all(
+      videos.map((video) => this.upsertVideoFromDisplay(account, video, logger, requestId))
+    );
+
+    await this.accountModel
+      .updateOne(
+        { _id: account._id },
+        { $set: { "syncMetadata.lastVideoSyncAt": new Date() } }
+      )
+      .exec();
+
+    const connection = await this.buildVideoConnection(account._id, limit, cursor);
+
+    await this.recordAuditLog({
+      user,
+      action: "tiktok.video.list",
+      logger,
+      requestId,
+      summary: `Fetched ${videos.length} TikTok videos for review.`
+    });
+
+    return connection;
+  }
+
+  async submitToChallenge(params: SubmitToChallengeParams) {
+    const { user, challengeId, tiktokVideoId, logger, requestId, ipAddress, userAgent } = params;
+    const account = await this.resolveCreatorAccount(user, logger, requestId);
+    const videoDoc = await this.ensureVideoAvailable(account, tiktokVideoId, logger, requestId);
+
+    const slug = normalizeChallengeId(challengeId);
+    if (!slug) {
+      throw new BadRequestException("A valid challenge id is required.");
+    }
+
+    const challenge = await this.challengeModel.findOne({ slug }).exec();
+    if (!challenge) {
+      throw new BadRequestException("Challenge not found.");
+    }
+
+    const creatorUserId = new Types.ObjectId(user.id);
+    const existing = await this.submissionModel
+      .findOne({
+        challengeId: challenge._id,
+        creatorUserId,
+        videoId: videoDoc._id
+      })
+      .exec();
+
+    if (existing) {
+      return this.hydrateSubmission(existing._id, logger, requestId);
+    }
+
+    const submission = await this.submissionModel.create({
+      challengeId: challenge._id,
+      creatorUserId,
+      videoId: videoDoc._id,
+      state: SubmissionState.Pending
+    });
+
+    await this.recordAuditLog({
+      user,
+      action: "tiktok.submission.create",
+      logger,
+      requestId,
+      ipAddress,
+      userAgent,
+      targetId: String(challenge._id),
+      summary: `Submitted TikTok video ${tiktokVideoId} to challenge ${slug}.`
+    });
+
+    return this.hydrateSubmission(submission._id, logger, requestId);
+  }
+
+  async fetchVideoMetrics(params: {
+    user: AuthenticatedUser;
+    tiktokVideoId: string;
+    logger: Logger;
+    requestId: string;
+  }) {
+    const { user, tiktokVideoId, logger, requestId } = params;
+    const account = await this.resolveCreatorAccount(user, logger, requestId);
+    const accessToken = await this.ensureValidAccessToken(account, logger, requestId);
+
+    const response = await this.callDisplayApi<TikTokDisplayMetricsResponse>(
+      DISPLAY_VIDEO_DATA_PATH,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`
+        },
+        body: JSON.stringify({
+          video_ids: [tiktokVideoId]
+        })
+      },
+      { rateLimitKey: "video_metrics", logger, requestId }
+    );
+
+    const metrics = response.data?.metrics?.find((entry) => entry.id === tiktokVideoId)?.stats ?? {};
+
+    await this.accountModel
+      .updateOne(
+        { _id: account._id },
+        {
+          $set: {
+            "syncMetadata.lastMetricsRefreshAt": new Date(),
+            "syncMetadata.lastMetricsErrorAt": null
+          }
+        }
+      )
+      .exec();
+
+    return sanitizeMetrics(metrics);
+  }
+
+  private async resolveCreatorAccount(
+    user: AuthenticatedUser,
+    logger: Logger,
+    requestId: string
+  ): Promise<TikTokAccountDocument> {
+    if (!user.tiktokUserId) {
+      logger.warn({ event: "tiktok.account.missing", requestId, userId: user.id }, "User is not linked to TikTok");
+      throw new UnauthorizedException("Your account is not linked to TikTok.");
+    }
+
+    const account = await this.accountModel.findOne({ openId: user.tiktokUserId }).exec();
+
+    if (!account) {
+      logger.warn({ event: "tiktok.account.not_found", requestId, userId: user.id }, "TikTok account record missing");
+      throw new UnauthorizedException("TikTok account not found. Please re-link your account.");
+    }
+
+    return account;
+  }
+
+  private async ensureValidAccessToken(
+    account: TikTokAccountDocument,
+    logger: Logger,
+    requestId: string
+  ): Promise<string> {
+    const { accessToken, refreshToken, keyId } = this.decryptAccountTokens(account);
+    const expiresAt = account.accessTokenExpiresAt?.getTime() ?? 0;
+
+    if (expiresAt > Date.now() + 60_000) {
+      return accessToken;
+    }
+
+    logger.info({ event: "tiktok.token.refresh", requestId, accountId: account.id }, "Refreshing TikTok access token");
+
+    await this.refreshAccessToken({
+      account,
+      refreshToken,
+      logger,
+      requestId
+    });
+
+    return this.tokenService.decryptAccountToken(account.accessToken, account.accessToken.keyId);
+  }
+
+  private decryptAccountTokens(account: TikTokAccountDocument) {
+    const keyId = account.accessToken.keyId;
+    const accessToken = this.tokenService.decryptAccountToken(account.accessToken, keyId);
+    const refreshToken = this.tokenService.decryptAccountToken(account.refreshToken, keyId);
+
+    return { accessToken, refreshToken, keyId };
+  }
+
+  private async refreshAccessToken(params: {
+    account: TikTokAccountDocument;
+    refreshToken: string;
+    logger: Logger;
+    requestId: string;
+  }): Promise<void> {
+    const { account, refreshToken, logger, requestId } = params;
+
+    if (!CLIENT_KEY || !CLIENT_SECRET) {
+      throw new UnauthorizedException("TikTok Display API credentials are not configured.");
+    }
+
+    const response = await fetch(TOKEN_REFRESH_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        client_key: CLIENT_KEY,
+        client_secret: CLIENT_SECRET,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken
+      })
+    });
+
+    if (!response.ok) {
+      const errorBody = await safeParseJson(response);
+      logger.error(
+        { event: "tiktok.token.refresh_failed", status: response.status, body: errorBody, requestId },
+        "TikTok token refresh failed"
+      );
+      throw new UnauthorizedException("Unable to refresh TikTok credentials. Please re-link your account.");
+    }
+
+    const payload = (await response.json()) as {
+      data?: {
+        access_token?: string;
+        refresh_token?: string;
+        expires_in?: number;
+        refresh_expires_in?: number;
+      };
+    };
+
+    const data = payload.data;
+    if (!data?.access_token || !data.refresh_token || !data.expires_in || !data.refresh_expires_in) {
+      logger.error({ event: "tiktok.token.refresh_payload_invalid", payload, requestId }, "Unexpected TikTok refresh payload");
+      throw new UnauthorizedException("TikTok did not return new credentials.");
+    }
+
+    const encryptedAccess = this.tokenService.encrypt(data.access_token);
+    const encryptedRefresh = this.tokenService.encrypt(data.refresh_token);
+
+    const accessTokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
+    const refreshTokenExpiresAt = new Date(Date.now() + data.refresh_expires_in * 1000);
+
+    await this.accountModel
+      .updateOne(
+        { _id: account._id },
+        {
+          $set: {
+            accessToken: {
+              keyId: this.tokenService.keyId,
+              ciphertext: encryptedAccess.ciphertext,
+              iv: encryptedAccess.iv,
+              authTag: encryptedAccess.authTag
+            },
+            refreshToken: {
+              keyId: this.tokenService.keyId,
+              ciphertext: encryptedRefresh.ciphertext,
+              iv: encryptedRefresh.iv,
+              authTag: encryptedRefresh.authTag
+            },
+            accessTokenExpiresAt,
+            refreshTokenExpiresAt
+          }
+        }
+      )
+      .exec();
+
+    account.accessToken = {
+      keyId: this.tokenService.keyId,
+      ciphertext: encryptedAccess.ciphertext,
+      iv: encryptedAccess.iv,
+      authTag: encryptedAccess.authTag
+    } as TikTokAccountDocument["accessToken"];
+    account.refreshToken = {
+      keyId: this.tokenService.keyId,
+      ciphertext: encryptedRefresh.ciphertext,
+      iv: encryptedRefresh.iv,
+      authTag: encryptedRefresh.authTag
+    } as TikTokAccountDocument["refreshToken"];
+    account.accessTokenExpiresAt = accessTokenExpiresAt;
+    account.refreshTokenExpiresAt = refreshTokenExpiresAt;
+
+    await this.userModel
+      .updateOne(
+        { _id: account.userId },
+        {
+          $set: {
+            "tiktokAuth.keyId": this.tokenService.keyId,
+            "tiktokAuth.accessToken": encryptedAccess.ciphertext,
+            "tiktokAuth.accessTokenIv": encryptedAccess.iv,
+            "tiktokAuth.accessTokenTag": encryptedAccess.authTag,
+            "tiktokAuth.refreshToken": encryptedRefresh.ciphertext,
+            "tiktokAuth.refreshTokenIv": encryptedRefresh.iv,
+            "tiktokAuth.refreshTokenTag": encryptedRefresh.authTag,
+            "tiktokAuth.accessTokenExpiresAt": accessTokenExpiresAt,
+            "tiktokAuth.refreshTokenExpiresAt": refreshTokenExpiresAt
+          }
+        }
+      )
+      .exec();
+
+    return;
+  }
+
+  private async ensureVideoAvailable(
+    account: TikTokAccountDocument,
+    tiktokVideoId: string,
+    logger: Logger,
+    requestId: string
+  ): Promise<VideoDocument> {
+    const existing = await this.videoModel.findOne({ tiktokVideoId }).exec();
+    if (existing) {
+      return existing;
+    }
+
+    const accessToken = await this.ensureValidAccessToken(account, logger, requestId);
+    const response = await this.callDisplayApi<TikTokDisplayListResponse>(
+      DISPLAY_VIDEO_LIST_PATH,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`
+        },
+        body: JSON.stringify({
+          video_ids: [tiktokVideoId],
+          max_count: 1
+        })
+      },
+      { rateLimitKey: "video_lookup", logger, requestId }
+    );
+
+    const video = (response.data?.videos ?? []).find((item) => item.id === tiktokVideoId);
+    if (!video) {
+      throw new BadRequestException("TikTok video could not be located.");
+    }
+
+    await this.upsertVideoFromDisplay(account, video, logger, requestId);
+
+    const hydrated = await this.videoModel.findOne({ tiktokVideoId }).exec();
+    if (!hydrated) {
+      throw new BadRequestException("Failed to persist TikTok video. Please try again.");
+    }
+
+    return hydrated;
+  }
+
+  private async upsertVideoFromDisplay(
+    account: TikTokAccountDocument,
+    video: TikTokDisplayVideo,
+    logger: Logger,
+    requestId: string
+  ) {
+    if (!video.id) {
+      return;
+    }
+
+    const shareUrl = video.share_url ?? buildShareUrl(video.id, account.username);
+    const embed = buildEmbed(shareUrl, video.embed_html, video.author?.username);
+    const sanitizedEmbed = tikTokEmbedSchema.parse(embed);
+
+    const metrics = sanitizeMetrics(video.stats);
+    const postedAt = video.create_time ? new Date(video.create_time * 1000) : undefined;
+
+    await this.videoModel
+      .findOneAndUpdate(
+        { tiktokVideoId: video.id },
+        {
+          $set: {
+            ownerTikTokAccountId: account._id,
+            shareUrl,
+            caption: sanitizeCaption(video.description),
+            postedAt,
+            embed: sanitizedEmbed,
+            metrics,
+            lastRefreshedAt: new Date()
+          },
+          $setOnInsert: {
+            ownerTikTokAccountId: account._id
+          }
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      )
+      .exec();
+
+    logger.debug({ event: "tiktok.video.upsert", requestId, videoId: video.id }, "Upserted TikTok video");
+  }
+
+  private async buildVideoConnection(
+    accountId: Types.ObjectId,
+    limit: number,
+    cursor: ReturnType<typeof decodeVideoCursor>
+  ): Promise<VideoConnectionResult> {
+    const conditions: Record<string, unknown>[] = [{ ownerTikTokAccountId: accountId }];
+
+    if (cursor) {
+      conditions.push({
+        $or: [
+          { postedAt: { $lt: cursor.postedAt } },
+          { postedAt: cursor.postedAt, _id: { $lt: cursor.id } }
+        ]
+      });
+    }
+
+    const query = conditions.length > 1 ? { $and: conditions } : conditions[0];
+
+    const documents = await this.videoModel
+      .find(query)
+      .sort({ postedAt: -1, _id: -1 })
+      .limit(limit + 1)
+      .populate({ path: "ownerTikTokAccountId", model: TikTokAccountEntity.name })
+      .exec();
+
+    const hasNextPage = documents.length > limit;
+    const window = hasNextPage ? documents.slice(0, -1) : documents;
+
+    const edges = window.map((doc) => {
+      const owner = doc.ownerTikTokAccountId as unknown as TikTokAccountDocument;
+      const node = toVideoNode(doc, owner);
+      const edgeCursor = encodeVideoCursor(doc.postedAt ?? doc.createdAt ?? new Date(), doc._id);
+      return { cursor: edgeCursor, node };
+    });
+
+    const endCursor = edges.length > 0 ? edges[edges.length - 1]?.cursor ?? null : null;
+
+    return {
+      edges,
+      pageInfo: {
+        endCursor,
+        hasNextPage
+      }
+    };
+  }
+
+  private async hydrateSubmission(submissionId: Types.ObjectId, logger: Logger, requestId: string) {
+    const submission = await this.submissionModel
+      .findById(submissionId)
+      .populate({
+        path: "videoId",
+        model: VideoEntity.name,
+        populate: { path: "ownerTikTokAccountId", model: TikTokAccountEntity.name }
+      })
+      .exec();
+
+    if (!submission) {
+      throw new BadRequestException("Submission could not be loaded.");
+    }
+
+    const videoDoc = submission.videoId as unknown as VideoDocument;
+    const owner = videoDoc.ownerTikTokAccountId as unknown as TikTokAccountDocument;
+    const node = toVideoNode(videoDoc, owner);
+
+    logger.info({ event: "tiktok.submission.hydrated", submissionId: submission.id, requestId }, "Hydrated submission payload");
+
+    return {
+      id: submission.id,
+      challengeId: String(submission.challengeId),
+      creatorUserId: String(submission.creatorUserId),
+      videoId: videoDoc.id,
+      state: submission.state,
+      rejectionReason: submission.rejectionReason ?? null,
+      createdAt: submission.createdAt,
+      updatedAt: submission.updatedAt,
+      video: node
+    };
+  }
+
+  private async recordAuditLog(params: {
+    user: AuthenticatedUser;
+    action: AuditLogAction;
+    logger: Logger;
+    requestId: string;
+    ipAddress?: string;
+    userAgent?: string;
+    summary?: string;
+    targetId?: string;
+    severity?: AuditLogSeverity;
+  }) {
+    const { user, action, logger, requestId, ipAddress, userAgent, summary, targetId, severity } = params;
+
+    try {
+      await this.auditLogModel.create({
+        actorId: new Types.ObjectId(user.id),
+        actorRoles: user.roles,
+        action,
+        targetId,
+        context: {
+          requestId,
+          ipAddress,
+          userAgent,
+          summary
+        },
+        severity: severity ?? "info"
+      });
+    } catch (error) {
+      logger.error({ event: "tiktok.audit.log_failed", error, requestId, action }, "Failed to persist audit log");
+    }
+  }
+
+  private async callDisplayApi<T>(
+    path: string,
+    init: RequestInit,
+    meta: { rateLimitKey: string; logger: Logger; requestId: string }
+  ): Promise<T> {
+    const { rateLimitKey, logger, requestId } = meta;
+    const rateKey = `tiktok:display:${rateLimitKey}`;
+
+    const rateResult = await this.rateLimitService.consume(rateKey, { windowMs: 60_000, max: RATE_LIMIT_PER_MIN });
+    if (!rateResult.allowed) {
+      logger.warn({ event: "tiktok.display.rate_limited", requestId, rateKey }, "Display API rate limit hit");
+      throw new BadRequestException("TikTok Display API rate limit exceeded. Please try again soon.");
+    }
+
+    const url = new URL(path, DISPLAY_API_BASE_URL).toString();
+    const response = await fetch(url, init);
+
+    const body = await safeParseJson(response);
+
+    if (!response.ok) {
+      logger.error({ event: "tiktok.display.error", status: response.status, body, requestId }, "TikTok Display API error");
+      throw new BadRequestException("TikTok Display API responded with an error.");
+    }
+
+    if (body?.error) {
+      logger.error({ event: "tiktok.display.payload_error", payload: body, requestId }, "TikTok Display API returned an error payload");
+      throw new BadRequestException(body.error.message ?? "TikTok Display API reported an error.");
+    }
+
+    return body as T;
+  }
+}
+
+const sanitizePageSize = (first?: number): number => {
+  if (typeof first !== "number" || !Number.isFinite(first) || first <= 0) {
+    return Math.min(50, Math.max(1, PAGE_SIZE));
+  }
+
+  return Math.min(50, Math.floor(first));
+};
+
+const sanitizeCaption = (value?: string | null): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.slice(0, 2200);
+};
+
+const sanitizeMetrics = (stats: TikTokDisplayVideo["stats"] | undefined) => ({
+  likeCount: Math.max(0, Math.trunc(stats?.digg_count ?? 0)),
+  commentCount: Math.max(0, Math.trunc(stats?.comment_count ?? 0)),
+  shareCount: Math.max(0, Math.trunc(stats?.share_count ?? 0)),
+  viewCount: Math.max(0, Math.trunc(stats?.play_count ?? stats?.view_count ?? 0))
+});
+
+const buildShareUrl = (videoId: string, username?: string | null) => {
+  if (username) {
+    return `https://www.tiktok.com/@${username}/video/${videoId}`;
+  }
+
+  return `https://www.tiktok.com/@trendpot/video/${videoId}`;
+};
+
+const buildEmbed = (shareUrl: string, embedHtml?: string, username?: string | null): TikTokEmbed => {
+  if (embedHtml) {
+    return {
+      provider: "tiktok",
+      html: embedHtml,
+      scriptUrl: "https://www.tiktok.com/embed.js",
+      width: undefined,
+      height: undefined,
+      thumbnailUrl: undefined,
+      authorName: username ?? undefined,
+      authorUrl: username ? `https://www.tiktok.com/@${username}` : undefined
+    };
+  }
+
+  const html = `<blockquote class="tiktok-embed" cite="${shareUrl}" data-video-id="${shareUrl}"></blockquote>`;
+
+  return {
+    provider: "tiktok",
+    html,
+    scriptUrl: "https://www.tiktok.com/embed.js",
+    width: undefined,
+    height: undefined,
+    thumbnailUrl: undefined,
+    authorName: username ?? undefined,
+    authorUrl: username ? `https://www.tiktok.com/@${username}` : undefined
+  };
+};
+
+const encodeVideoCursor = (postedAt: Date, id: Types.ObjectId): string => {
+  return Buffer.from(`${postedAt.toISOString()}::${id.toHexString()}`).toString("base64");
+};
+
+const decodeVideoCursor = (cursor?: string): { postedAt: Date; id: Types.ObjectId } | null => {
+  if (!cursor) {
+    return null;
+  }
+
+  try {
+    const raw = Buffer.from(cursor, "base64").toString("utf8");
+    const [postedAtIso, idHex] = raw.split("::");
+    const postedAt = new Date(postedAtIso);
+    if (!postedAtIso || Number.isNaN(postedAt.getTime()) || !idHex) {
+      return null;
+    }
+
+    return {
+      postedAt,
+      id: new Types.ObjectId(idHex)
+    };
+  } catch {
+    return null;
+  }
+};
+
+const normalizeChallengeId = (value: string): string => {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+};
+
+const safeParseJson = async (response: Response): Promise<any> => {
+  try {
+    return await response.clone().json();
+  } catch {
+    return null;
+  }
+};
+
+const toVideoNode = (video: VideoDocument, owner: TikTokAccountDocument) => ({
+  id: video.id,
+  tiktokVideoId: video.tiktokVideoId,
+  ownerAccountId: owner.id,
+  shareUrl: video.shareUrl,
+  caption: video.caption ?? null,
+  postedAt: video.postedAt ?? null,
+  embed: video.embed,
+  metrics: video.metrics,
+  lastRefreshedAt: video.lastRefreshedAt,
+  createdAt: video.createdAt,
+  updatedAt: video.updatedAt,
+  owner: {
+    id: owner.id,
+    username: owner.username,
+    displayName: owner.displayName ?? null,
+    avatarUrl: owner.avatarUrl ?? null,
+    scopes: owner.scopes,
+    accessTokenExpiresAt: owner.accessTokenExpiresAt,
+    refreshTokenExpiresAt: owner.refreshTokenExpiresAt,
+    createdAt: owner.createdAt,
+    updatedAt: owner.updatedAt
+  }
+});
+

--- a/apps/web/src/components/challenges/challenge-detail.integration.test.tsx
+++ b/apps/web/src/components/challenges/challenge-detail.integration.test.tsx
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import type { Challenge } from "@trendpot/types";
+import { challengeQueryKey } from "../../lib/challenge-queries";
+import { ChallengeDetail } from "./challenge-detail";
+
+test("challenge detail renders TikTok submissions with metrics", () => {
+  const challengeId = "challenge-123";
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: Infinity, retry: false } }
+  });
+
+  const embedHtml =
+    '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123"><section><a href="https://www.tiktok.com/@creator/video/123">Watch on TikTok</a></section></blockquote>';
+
+  const challenge: Challenge = {
+    id: challengeId,
+    title: "Clean Water Challenge",
+    tagline: "Bring safe water to rural schools",
+    description: "Every donation supports new wells and hygiene training.",
+    raised: 2500000,
+    goal: 5000000,
+    currency: "KES",
+    status: "live",
+    updatedAt: "2024-05-10T00:00:00.000Z",
+    createdAt: "2024-05-01T00:00:00.000Z",
+    version: 3,
+    submissions: {
+      edges: [
+        {
+          cursor: "cursor-1",
+          node: {
+            id: "submission-1",
+            challengeId,
+            creatorUserId: "creator-1",
+            videoId: "video-1",
+            state: "approved",
+            rejectionReason: null,
+            createdAt: "2024-05-05T00:00:00.000Z",
+            updatedAt: "2024-05-10T00:00:00.000Z",
+            video: {
+              id: "video-1",
+              tiktokVideoId: "123",
+              ownerAccountId: "account-1",
+              shareUrl: "https://www.tiktok.com/@creator/video/123",
+              caption: "Hero submission caption",
+              postedAt: "2024-05-02T00:00:00.000Z",
+              embed: {
+                provider: "tiktok",
+                html: embedHtml,
+                scriptUrl: "https://www.tiktok.com/embed.js",
+                width: 325,
+                height: 720,
+                authorName: "Creator One",
+                authorUrl: "https://www.tiktok.com/@creator"
+              },
+              metrics: {
+                viewCount: 9800,
+                likeCount: 1200,
+                commentCount: 230,
+                shareCount: 54
+              },
+              lastRefreshedAt: "2024-05-10T00:00:00.000Z",
+              createdAt: "2024-05-02T00:00:00.000Z",
+              updatedAt: "2024-05-10T00:00:00.000Z"
+            }
+          }
+        },
+        {
+          cursor: "cursor-2",
+          node: {
+            id: "submission-2",
+            challengeId,
+            creatorUserId: "creator-2",
+            videoId: "video-2",
+            state: "pending",
+            rejectionReason: null,
+            createdAt: "2024-05-06T00:00:00.000Z",
+            updatedAt: "2024-05-10T00:00:00.000Z",
+            video: {
+              id: "video-2",
+              tiktokVideoId: "456",
+              ownerAccountId: "account-1",
+              shareUrl: "https://www.tiktok.com/@creator/video/456",
+              caption: "Secondary submission",
+              postedAt: "2024-05-03T00:00:00.000Z",
+              embed: {
+                provider: "tiktok",
+                html: embedHtml.replace("123", "456"),
+                scriptUrl: "https://www.tiktok.com/embed.js"
+              },
+              metrics: {
+                viewCount: 4500,
+                likeCount: 320,
+                commentCount: 44,
+                shareCount: 18
+              },
+              lastRefreshedAt: "2024-05-10T00:00:00.000Z",
+              createdAt: "2024-05-03T00:00:00.000Z",
+              updatedAt: "2024-05-10T00:00:00.000Z"
+            }
+          }
+        }
+      ],
+      pageInfo: { endCursor: "cursor-2", hasNextPage: false }
+    }
+  };
+
+  queryClient.setQueryData(challengeQueryKey(challengeId), challenge);
+
+  const markup = renderToString(
+    <QueryClientProvider client={queryClient}>
+      <ChallengeDetail challengeId={challengeId} />
+    </QueryClientProvider>
+  );
+
+  assert.ok(markup.includes("Clean Water Challenge"));
+  assert.ok(markup.includes("Watch on TikTok"));
+  assert.ok(markup.includes("TikTok submissions"));
+  assert.ok(markup.includes("Hero submission caption"));
+  assert.ok(markup.includes("Secondary submission"));
+  assert.ok(markup.includes("9800"));
+  assert.ok(markup.includes("Preparing TikTok embed"));
+  assert.ok(markup.includes("tiktok-embed"));
+});

--- a/apps/web/src/components/challenges/challenge-detail.tsx
+++ b/apps/web/src/components/challenges/challenge-detail.tsx
@@ -2,8 +2,22 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@trendpot/ui";
+import type { Submission } from "@trendpot/types";
 import { challengeQueryOptions } from "../../lib/challenge-queries";
 import { calculateCompletionPercentage, formatCurrencyFromCents } from "../../lib/money";
+import { TikTokEmbed } from "./tiktok-embed";
+
+const METRIC_FORMATTER = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 0,
+  useGrouping: false
+});
+
+const SUBMISSION_STATE_LABELS: Record<Submission["state"], string> = {
+  pending: "Pending review",
+  approved: "Approved",
+  rejected: "Rejected",
+  removed: "Removed"
+};
 
 interface ChallengeDetailProps {
   challengeId: string;
@@ -41,6 +55,9 @@ export function ChallengeDetail({ challengeId }: ChallengeDetailProps) {
   const raised = formatCurrencyFromCents(data.raised, data.currency);
   const goal = formatCurrencyFromCents(data.goal, data.currency);
   const statusLabel = data.status.charAt(0).toUpperCase() + data.status.slice(1);
+  const submissions = data.submissions?.edges?.map((edge) => edge.node) ?? [];
+  const heroSubmission = submissions[0];
+  const secondarySubmissions = submissions.slice(1);
 
   return (
     <article className="space-y-8">
@@ -72,6 +89,104 @@ export function ChallengeDetail({ challengeId }: ChallengeDetailProps) {
         <p className="text-sm text-slate-300 whitespace-pre-line">{data.description}</p>
       </section>
 
+      <section className="space-y-6">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-white">TikTok submissions</h2>
+          <p className="text-sm text-slate-300">
+            Spotlighted creator videos refresh as metrics update so you can keep tabs on performance in near real time.
+          </p>
+        </div>
+
+        {heroSubmission ? (
+          <>
+            <div className="space-y-6 lg:grid lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] lg:items-start lg:gap-6 lg:space-y-0">
+              <div className="-mx-6 lg:mx-0">
+                <div className="border-y border-slate-800 bg-slate-900/80 lg:overflow-hidden lg:rounded-3xl lg:border">
+                  <TikTokEmbed embed={heroSubmission.video.embed} className="aspect-[9/16] overflow-hidden bg-black" />
+                </div>
+              </div>
+              <aside className="rounded-3xl border border-slate-800 bg-slate-900/80 p-6 space-y-4">
+                <div className="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs uppercase tracking-wide text-emerald-300">
+                  <span>Featured</span>
+                  <span className="font-semibold">{formatSubmissionState(heroSubmission.state)}</span>
+                </div>
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold text-white">
+                    {heroSubmission.video.caption?.trim() || "TikTok challenge spotlight"}
+                  </h3>
+                  <p className="text-sm text-slate-300">
+                    Submitted {formatDateTime(heroSubmission.createdAt)} · Last refreshed {formatDateTime(heroSubmission.video.lastRefreshedAt)}
+                  </p>
+                </div>
+                <div className="grid grid-cols-2 gap-4 text-sm text-slate-300">
+                  {renderMetric("Views", heroSubmission.video.metrics.viewCount)}
+                  {renderMetric("Likes", heroSubmission.video.metrics.likeCount)}
+                  {renderMetric("Comments", heroSubmission.video.metrics.commentCount)}
+                  {renderMetric("Shares", heroSubmission.video.metrics.shareCount)}
+                </div>
+                {heroSubmission.rejectionReason ? (
+                  <p className="rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+                    {heroSubmission.rejectionReason}
+                  </p>
+                ) : null}
+                <div className="flex flex-wrap items-center gap-3 pt-1">
+                  <a
+                    href={heroSubmission.video.shareUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center rounded-full border border-slate-700 px-4 py-2 text-sm font-medium text-slate-100 transition hover:border-slate-500"
+                  >
+                    Watch on TikTok
+                  </a>
+                  {heroSubmission.video.embed.authorName ? (
+                    <span className="text-xs uppercase tracking-wide text-slate-400">
+                      Creator · {heroSubmission.video.embed.authorName}
+                    </span>
+                  ) : null}
+                </div>
+              </aside>
+            </div>
+
+            {secondarySubmissions.length > 0 ? (
+              <div className="grid gap-6 md:grid-cols-2">
+                {secondarySubmissions.map((submission) => (
+                  <article key={submission.id} className="overflow-hidden rounded-3xl border border-slate-800 bg-slate-900/80">
+                    <TikTokEmbed embed={submission.video.embed} className="aspect-[9/16] overflow-hidden bg-black" />
+                    <div className="space-y-3 p-5 text-sm text-slate-300">
+                      <div className="flex items-center justify-between text-xs uppercase tracking-wide text-slate-400">
+                        <span>{formatSubmissionState(submission.state)}</span>
+                        <span>{formatDateTime(submission.video.lastRefreshedAt)}</span>
+                      </div>
+                      <h3 className="text-base font-semibold text-white">
+                        {submission.video.caption?.trim() || "TikTok submission"}
+                      </h3>
+                      <div className="grid grid-cols-2 gap-3">
+                        {renderMetric("Views", submission.video.metrics.viewCount)}
+                        {renderMetric("Likes", submission.video.metrics.likeCount)}
+                        {renderMetric("Comments", submission.video.metrics.commentCount)}
+                        {renderMetric("Shares", submission.video.metrics.shareCount)}
+                      </div>
+                      <a
+                        href={submission.video.shareUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center justify-center rounded-full border border-slate-700 px-3 py-2 text-xs font-medium text-slate-100 transition hover:border-slate-500"
+                      >
+                        View on TikTok
+                      </a>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : null}
+          </>
+        ) : (
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/80 p-6 text-sm text-slate-300">
+            No TikTok submissions have been highlighted for this challenge yet. Check back soon as creators join in.
+          </div>
+        )}
+      </section>
+
       <section className="rounded-3xl border border-slate-800 bg-slate-900/80 p-6 text-sm text-slate-300">
         <h2 className="text-lg font-semibold text-white">Operational metadata</h2>
         <dl className="mt-4 grid gap-4 sm:grid-cols-2">
@@ -81,16 +196,41 @@ export function ChallengeDetail({ challengeId }: ChallengeDetailProps) {
           </div>
           <div>
             <dt className="text-xs uppercase tracking-wide text-slate-400">Created</dt>
-            <dd className="mt-1 text-base text-white">{new Date(data.createdAt).toLocaleString()}</dd>
+            <dd className="mt-1 text-base text-white">{formatDateTime(data.createdAt)}</dd>
           </div>
           <div>
             <dt className="text-xs uppercase tracking-wide text-slate-400">Last updated</dt>
-            <dd className="mt-1 text-base text-white">{new Date(data.updatedAt).toLocaleString()}</dd>
+            <dd className="mt-1 text-base text-white">{formatDateTime(data.updatedAt)}</dd>
           </div>
         </dl>
       </section>
     </article>
   );
+}
+
+function renderMetric(label: string, value: number) {
+  return (
+    <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-3">
+      <p className="text-xs uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="mt-1 text-base font-semibold text-white">{formatMetricValue(value)}</p>
+    </div>
+  );
+}
+
+function formatMetricValue(value: number): string {
+  return METRIC_FORMATTER.format(value);
+}
+
+function formatSubmissionState(state: Submission["state"]): string {
+  return SUBMISSION_STATE_LABELS[state] ?? state;
+}
+
+function formatDateTime(value: string): string {
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
 }
 
 function ChallengeDetailSkeleton() {
@@ -109,6 +249,23 @@ function ChallengeDetailSkeleton() {
       <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6">
         <div className="h-5 w-32 rounded bg-slate-800/80" />
         <div className="mt-3 h-16 w-full rounded bg-slate-800/70" />
+      </div>
+      <div className="space-y-4">
+        <div className="h-5 w-48 rounded bg-slate-800/80" />
+        <div className="h-4 w-3/4 rounded bg-slate-800/70" />
+        <div className="h-[420px] w-full rounded-3xl bg-slate-900/60" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="h-64 rounded-3xl bg-slate-900/60" />
+          <div className="h-64 rounded-3xl bg-slate-900/60" />
+        </div>
+      </div>
+      <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6">
+        <div className="h-5 w-48 rounded bg-slate-800/80" />
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          <div className="h-16 rounded bg-slate-800/70" />
+          <div className="h-16 rounded bg-slate-800/70" />
+          <div className="h-16 rounded bg-slate-800/70" />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/challenges/tiktok-embed.tsx
+++ b/apps/web/src/components/challenges/tiktok-embed.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { TikTokEmbed as TikTokEmbedPayload } from "@trendpot/types";
+
+const scriptPromises = new Map<string, Promise<void>>();
+
+function loadTikTokEmbedScript(src: string): Promise<void> {
+  if (typeof document === "undefined") {
+    return Promise.resolve();
+  }
+
+  const existing = document.querySelector<HTMLScriptElement>(`script[src="${src}"]`);
+  if (existing?.dataset.loaded === "true") {
+    return Promise.resolve();
+  }
+
+  if (scriptPromises.has(src)) {
+    return scriptPromises.get(src)!;
+  }
+
+  const script = existing ?? document.createElement("script");
+
+  const promise = new Promise<void>((resolve, reject) => {
+    const handleLoad = () => {
+      script.dataset.loaded = "true";
+      resolve();
+    };
+
+    const handleError = () => {
+      scriptPromises.delete(src);
+      if (!existing) {
+        script.remove();
+      }
+      reject(new Error(`Failed to load TikTok embed script from ${src}`));
+    };
+
+    script.addEventListener("load", handleLoad, { once: true });
+    script.addEventListener("error", handleError, { once: true });
+  });
+
+  scriptPromises.set(src, promise);
+
+  if (!existing) {
+    script.async = true;
+    script.src = src;
+    document.body.appendChild(script);
+  }
+
+  return promise;
+}
+
+function invokeTikTokEmbedLoad() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const globalWithLoader = window as typeof window & { tiktokEmbedLoad?: () => void };
+  if (typeof globalWithLoader.tiktokEmbedLoad === "function") {
+    try {
+      globalWithLoader.tiktokEmbedLoad();
+    } catch (error) {
+      console.error("TikTok embed loader threw", error);
+    }
+  }
+}
+
+export interface TikTokEmbedProps {
+  embed: TikTokEmbedPayload;
+  className?: string;
+  loadingText?: string;
+  errorText?: string;
+}
+
+export function TikTokEmbed({
+  embed,
+  className,
+  loadingText = "Preparing TikTok embed…",
+  errorText = "We couldn't load this TikTok embed."
+}: TikTokEmbedProps) {
+  const [status, setStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const html = useMemo(() => ({ __html: embed.html }), [embed.html]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    setStatus("loading");
+    let cancelled = false;
+
+    loadTikTokEmbedScript(embed.scriptUrl)
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        setStatus("ready");
+        invokeTikTokEmbedLoad();
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        console.error(error);
+        setStatus("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [embed.scriptUrl, embed.html]);
+
+  return (
+    <div className={`relative w-full ${className ?? ""}`}>
+      <div ref={containerRef} className="h-full w-full" dangerouslySetInnerHTML={html} />
+      {status !== "ready" ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/70 text-center text-sm text-slate-200">
+          <span>{status === "error" ? errorText : loadingText}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "bullmq": "4.11.4",
     "ioredis": "5.4.1",
+    "mongoose": "8.3.2",
     "pino": "8.19.0",
     "@trendpot/types": "workspace:*",
     "@trendpot/utils": "workspace:*"

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,12 +1,60 @@
-import { Queue, Worker } from "bullmq";
+import { Queue, QueueScheduler, Worker } from "bullmq";
 import IORedis from "ioredis";
 import { withRetries } from "@trendpot/utils";
+import {
+  TIKTOK_INGESTION_QUEUE,
+  TIKTOK_REFRESH_QUEUE,
+  TikTokInitialSyncJob,
+  TikTokMetricsRefreshJob
+} from "@trendpot/types";
 import { createLeaderboardJobHandler } from "./leaderboard-job";
 import { workerLogger } from "./logger";
+import { createInitialSyncJobHandler, createMetricsRefreshJobHandler } from "./tiktok/tiktok-jobs";
 
-const connection = new IORedis(process.env.REDIS_URL ?? "redis://localhost:6379");
+const redisUrl = process.env.REDIS_URL ?? "redis://localhost:6379";
+const baseConnection = new IORedis(redisUrl);
+const queueConnection = baseConnection.duplicate();
+const schedulerConnection = baseConnection.duplicate();
+const redisPublisher = baseConnection.duplicate();
 
-export const leaderboardQueue = new Queue("leaderboard", { connection });
+const BACKOFF_DELAY = Number(process.env.TIKTOK_INGESTION_RETRY_BACKOFF_MS ?? 5000);
+const MAX_ATTEMPTS = Number(process.env.TIKTOK_INGESTION_MAX_ATTEMPTS ?? 5);
+const RATE_LIMIT_PER_MIN = Number(process.env.TIKTOK_INGESTION_RATE_LIMIT_PER_MIN ?? 90);
+const PER_QUEUE_RATE_LIMIT = Math.max(1, Math.floor(RATE_LIMIT_PER_MIN / 2));
+const INGESTION_CONCURRENCY = Number(process.env.TIKTOK_INGESTION_CONCURRENCY ?? 1);
+const REFRESH_CONCURRENCY = Number(process.env.TIKTOK_REFRESH_CONCURRENCY ?? 1);
+
+export const leaderboardQueue = new Queue("leaderboard", { connection: queueConnection });
+
+const ingestionQueue = new Queue<TikTokInitialSyncJob>(TIKTOK_INGESTION_QUEUE, {
+  connection: queueConnection,
+  defaultJobOptions: {
+    attempts: MAX_ATTEMPTS,
+    backoff: { type: "exponential", delay: BACKOFF_DELAY },
+    removeOnComplete: 100,
+    removeOnFail: 20
+  }
+});
+
+const refreshQueue = new Queue<TikTokMetricsRefreshJob>(TIKTOK_REFRESH_QUEUE, {
+  connection: queueConnection,
+  defaultJobOptions: {
+    attempts: MAX_ATTEMPTS,
+    backoff: { type: "exponential", delay: BACKOFF_DELAY },
+    removeOnComplete: 100,
+    removeOnFail: 20
+  }
+});
+
+const ingestionScheduler = new QueueScheduler(TIKTOK_INGESTION_QUEUE, {
+  connection: schedulerConnection.duplicate()
+});
+const refreshScheduler = new QueueScheduler(TIKTOK_REFRESH_QUEUE, {
+  connection: schedulerConnection.duplicate()
+});
+
+void ingestionScheduler.waitUntilReady();
+void refreshScheduler.waitUntilReady();
 
 const jobHandler = createLeaderboardJobHandler();
 
@@ -15,7 +63,36 @@ const jobHandler = createLeaderboardJobHandler();
 const worker = new Worker(
   leaderboardQueue.name,
   async () => withRetries(jobHandler, { retries: 2 }),
-  { connection }
+  { connection: baseConnection.duplicate() }
+);
+
+const initialSyncHandler = createInitialSyncJobHandler({ refreshQueue, redisPublisher });
+const metricsRefreshHandler = createMetricsRefreshJobHandler({ redisPublisher });
+
+const ingestionWorker = new Worker(
+  ingestionQueue.name,
+  async (job) => initialSyncHandler(job),
+  {
+    connection: baseConnection.duplicate(),
+    concurrency: INGESTION_CONCURRENCY,
+    limiter: {
+      max: PER_QUEUE_RATE_LIMIT,
+      duration: 60_000
+    }
+  }
+);
+
+const metricsWorker = new Worker(
+  refreshQueue.name,
+  async (job) => metricsRefreshHandler(job),
+  {
+    connection: baseConnection.duplicate(),
+    concurrency: REFRESH_CONCURRENCY,
+    limiter: {
+      max: PER_QUEUE_RATE_LIMIT,
+      duration: 60_000
+    }
+  }
 );
 
 worker.on("completed", (job, result) => {
@@ -32,7 +109,38 @@ worker.on("failed", (job, err) => {
   );
 });
 
+ingestionWorker.on("completed", (job, result) => {
+  workerLogger.info(
+    { jobId: job.id, queue: job.queueName, result },
+    "TikTok initial sync job completed"
+  );
+});
+
+ingestionWorker.on("failed", (job, err) => {
+  workerLogger.error(
+    { jobId: job?.id, queue: job?.queueName, err: err.message },
+    "TikTok initial sync job failed"
+  );
+});
+
+metricsWorker.on("completed", (job, result) => {
+  workerLogger.info(
+    { jobId: job.id, queue: job.queueName, result },
+    "TikTok metrics refresh job completed"
+  );
+});
+
+metricsWorker.on("failed", (job, err) => {
+  workerLogger.error(
+    { jobId: job?.id, queue: job?.queueName, err: err.message },
+    "TikTok metrics refresh job failed"
+  );
+});
+
 workerLogger.info(
-  { event: "bootstrap.complete", queue: leaderboardQueue.name },
+  {
+    event: "bootstrap.complete",
+    queues: [leaderboardQueue.name, ingestionQueue.name, refreshQueue.name]
+  },
   "Worker ready"
 );

--- a/apps/worker/src/mongo.ts
+++ b/apps/worker/src/mongo.ts
@@ -1,0 +1,35 @@
+import mongoose from "mongoose";
+import { workerLogger } from "./logger";
+
+const MONGODB_URI = process.env.MONGODB_URI ?? "mongodb://localhost:27017/trendpot";
+
+let connectionPromise: Promise<typeof mongoose> | null = null;
+
+export const connectMongo = async (): Promise<typeof mongoose> => {
+  if (mongoose.connection.readyState === 1) {
+    return mongoose;
+  }
+
+  if (!connectionPromise) {
+    mongoose.set("strictQuery", false);
+    connectionPromise = mongoose
+      .connect(MONGODB_URI, {
+        serverSelectionTimeoutMS: 10_000
+      })
+      .catch((error) => {
+        connectionPromise = null;
+        workerLogger.error(
+          { event: "mongo.connection_failed", message: (error as Error).message },
+          "Failed to connect to MongoDB"
+        );
+        throw error;
+      });
+  }
+
+  return connectionPromise;
+};
+
+export const getMongoDb = async () => {
+  const connection = await connectMongo();
+  return connection.connection.db;
+};

--- a/apps/worker/src/tiktok/tiktok-jobs.integration.test.ts
+++ b/apps/worker/src/tiktok/tiktok-jobs.integration.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Types } from "mongoose";
+
+import { TIKTOK_VIDEO_UPDATE_CHANNEL } from "@trendpot/types";
+import { TikTokTokenCipher } from "@trendpot/utils";
+import type IORedis from "ioredis";
+
+import { createMetricsRefreshJobHandler } from "./tiktok-jobs";
+
+test("metrics refresh handler updates metrics and publishes redis notifications", async (t) => {
+  const accountId = new Types.ObjectId();
+  const cipher = new TikTokTokenCipher();
+  const encryptedAccess = cipher.encrypt("access-token");
+  const encryptedRefresh = cipher.encrypt("refresh-token");
+
+  const accountRecord = {
+    _id: accountId,
+    userId: new Types.ObjectId(),
+    openId: "creator-open-id",
+    username: "creator",
+    scopes: ["video.data"],
+    accessToken: {
+      keyId: cipher.keyId,
+      ciphertext: encryptedAccess.ciphertext,
+      iv: encryptedAccess.iv,
+      authTag: encryptedAccess.authTag
+    },
+    refreshToken: {
+      keyId: cipher.keyId,
+      ciphertext: encryptedRefresh.ciphertext,
+      iv: encryptedRefresh.iv,
+      authTag: encryptedRefresh.authTag
+    },
+    accessTokenExpiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    refreshTokenExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+  };
+
+  const videoDocs = [
+    { tiktokVideoId: "video-1", ownerTikTokAccountId: accountId },
+    { tiktokVideoId: "video-2", ownerTikTokAccountId: accountId }
+  ];
+
+  const videoUpdates: Array<{ filter: unknown; update: unknown }> = [];
+  const accountUpdates: Array<{ filter: unknown; update: unknown }> = [];
+
+  const dbStub = {
+    collection(name: string) {
+      if (name === "tiktok_accounts") {
+        return {
+          findOne: async (filter: unknown) => {
+            assert.deepEqual(filter, { _id: accountId });
+            return accountRecord;
+          },
+          updateOne: async (filter: unknown, update: unknown) => {
+            accountUpdates.push({ filter, update });
+            return { acknowledged: true };
+          }
+        };
+      }
+
+      if (name === "videos") {
+        return {
+          find: () => ({
+            project: () => ({
+              toArray: async () => videoDocs
+            })
+          }),
+          updateOne: async (filter: unknown, update: { $set: { metrics: { viewCount: number } } }) => {
+            videoUpdates.push({ filter, update });
+            return { modifiedCount: 1 };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected collection ${name}`);
+    }
+  };
+
+  const published: Array<{ channel: string; payload: Record<string, unknown> }> = [];
+  const redisPublisher = {
+    publish: async (channel: string, message: string) => {
+      published.push({ channel, payload: JSON.parse(message) });
+      return 1;
+    }
+  };
+
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      data: {
+        metrics: [
+          { id: "video-1", stats: { play_count: 120, digg_count: 10, comment_count: 4, share_count: 2 } },
+          { id: "video-2", stats: { play_count: 80, digg_count: 5, comment_count: 1, share_count: 1 } }
+        ]
+      }
+    }
+  }) as unknown as Response;
+
+  const handler = createMetricsRefreshJobHandler({
+    redisPublisher: redisPublisher as unknown as IORedis,
+    getMongoDb: async () => dbStub as never
+  });
+
+  const job = {
+    id: "job-1",
+    queueName: "tiktok:refresh",
+    data: {
+      accountId: accountId.toHexString(),
+      reason: "manual",
+      queuedAt: new Date().toISOString(),
+      requestId: "req-123",
+      retryCount: 0
+    }
+  };
+
+  const result = await handler(job as never);
+
+  assert.equal(result.updated, 2);
+  assert.equal(result.total, 2);
+
+  assert.equal(videoUpdates.length, 2);
+  for (const update of videoUpdates) {
+    const set = (update.update as { $set: { metrics: { viewCount: number } } }).$set;
+    assert.ok(set.metrics.viewCount === 120 || set.metrics.viewCount === 80);
+    assert.ok(set.metrics.likeCount === undefined || typeof set.metrics.likeCount === "number");
+  }
+
+  assert.equal(accountUpdates.length, 1);
+  const accountUpdate = accountUpdates[0];
+  assert.deepEqual(accountUpdate.filter, { _id: accountId });
+
+  assert.equal(published.length, 1);
+  assert.equal(published[0].channel, `${TIKTOK_VIDEO_UPDATE_CHANNEL}:${accountId.toHexString()}`);
+  assert.equal(published[0].payload.event, "tiktok.videos.metrics_refreshed");
+  assert.equal(published[0].payload.updated, 2);
+  assert.equal(published[0].payload.total, 2);
+});

--- a/apps/worker/src/tiktok/tiktok-jobs.ts
+++ b/apps/worker/src/tiktok/tiktok-jobs.ts
@@ -1,0 +1,597 @@
+import { Job, Queue } from "bullmq";
+import IORedis from "ioredis";
+import { Types } from "mongoose";
+import type { Logger } from "pino";
+import {
+  TIKTOK_VIDEO_UPDATE_CHANNEL,
+  TikTokInitialSyncJob,
+  TikTokMetricsRefreshJob,
+  TIKTOK_REFRESH_QUEUE,
+  tiktokInitialSyncJobSchema,
+  tiktokMetricsRefreshJobSchema
+} from "@trendpot/types";
+import { TikTokTokenCipher, mapAccountTokenToEncryptedSecret } from "@trendpot/utils";
+import { getMongoDb } from "../mongo";
+import { workerLogger } from "../logger";
+import {
+  chunkArray,
+  sanitizeDisplayMetrics,
+  transformDisplayVideo,
+  type TikTokDisplayVideo
+} from "./transform";
+
+const DISPLAY_API_BASE_URL = process.env.TIKTOK_DISPLAY_API_BASE_URL ?? "https://open-api.tiktok.com";
+const TOKEN_REFRESH_ENDPOINT = process.env.TIKTOK_TOKEN_ENDPOINT ??
+  "https://open-api.tiktok.com/oauth/refresh_token/";
+const DISPLAY_VIDEO_LIST_PATH = "/v2/video/list/";
+const DISPLAY_VIDEO_DATA_PATH = "/v2/video/data/";
+const CLIENT_KEY = process.env.TIKTOK_CLIENT_KEY ?? "";
+const CLIENT_SECRET = process.env.TIKTOK_CLIENT_SECRET ?? "";
+const PAGE_SIZE = Number(process.env.TIKTOK_INGESTION_PAGE_SIZE ?? 20);
+const METRICS_BATCH_SIZE = Number(process.env.TIKTOK_INGESTION_METRICS_BATCH_SIZE ?? 20);
+const REFRESH_INTERVAL_MS = Number(process.env.TIKTOK_METRICS_REFRESH_INTERVAL_MS ?? 15 * 60 * 1000);
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+interface TikTokAccountRecord {
+  _id: Types.ObjectId;
+  userId: Types.ObjectId;
+  openId: string;
+  username: string;
+  scopes: string[];
+  accessToken: {
+    keyId: string;
+    ciphertext: string;
+    iv: string;
+    authTag: string;
+  };
+  refreshToken: {
+    keyId: string;
+    ciphertext: string;
+    iv: string;
+    authTag: string;
+  };
+  accessTokenExpiresAt: Date;
+  refreshTokenExpiresAt: Date;
+  syncMetadata?: {
+    lastVideoSyncAt?: Date;
+    lastProfileRefreshAt?: Date;
+    lastMetricsRefreshAt?: Date;
+    lastMetricsErrorAt?: Date;
+  };
+}
+
+interface TikTokVideoMetricsResponse {
+  data?: {
+    metrics?: Array<{ id: string; stats?: TikTokDisplayVideo["stats"] }>;
+  };
+  error?: {
+    code?: number;
+    message?: string;
+    log_id?: string;
+  };
+}
+
+interface TikTokVideoListResponse {
+  data?: {
+    videos?: TikTokDisplayVideo[];
+    cursor?: string;
+    has_more?: boolean;
+  };
+  error?: {
+    code?: number;
+    message?: string;
+    log_id?: string;
+  };
+}
+
+const tokenCipher = new TikTokTokenCipher();
+
+const safeParseJson = async (response: Response) => {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+};
+
+const decryptAccountToken = (token: TikTokAccountRecord["accessToken"], keyId: string): string => {
+  return tokenCipher.decrypt(mapAccountTokenToEncryptedSecret(token), { keyId });
+};
+
+const ensureValidAccessToken = async (
+  account: TikTokAccountRecord,
+  db: Awaited<ReturnType<typeof getMongoDb>>,
+  logger: Logger,
+  requestId?: string
+): Promise<{ accessToken: string; account: TikTokAccountRecord }> => {
+  const now = Date.now();
+  const expiry = new Date(account.accessTokenExpiresAt).getTime();
+  const accessToken = decryptAccountToken(account.accessToken, account.accessToken.keyId);
+
+  if (expiry > now + TOKEN_EXPIRY_BUFFER_MS) {
+    return { accessToken, account };
+  }
+
+  return refreshAccessToken(account, db, logger, requestId);
+};
+
+const refreshAccessToken = async (
+  account: TikTokAccountRecord,
+  db: Awaited<ReturnType<typeof getMongoDb>>,
+  logger: Logger,
+  requestId?: string
+): Promise<{ accessToken: string; account: TikTokAccountRecord }> => {
+  if (!CLIENT_KEY || !CLIENT_SECRET) {
+    throw new Error("TikTok Display API credentials are not configured");
+  }
+
+  const refreshToken = decryptAccountToken(account.refreshToken, account.refreshToken.keyId);
+  logger.info(
+    { event: "tiktok.token.refresh", accountId: account._id.toHexString(), requestId },
+    "Refreshing TikTok access token"
+  );
+
+  const response = await fetch(TOKEN_REFRESH_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      client_key: CLIENT_KEY,
+      client_secret: CLIENT_SECRET,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken
+    })
+  });
+
+  if (!response.ok) {
+    const errorBody = await safeParseJson(response);
+    logger.error(
+      {
+        event: "tiktok.token.refresh_failed",
+        status: response.status,
+        body: errorBody,
+        requestId,
+        accountId: account._id.toHexString()
+      },
+      "TikTok token refresh failed"
+    );
+    throw new Error("Unable to refresh TikTok credentials");
+  }
+
+  const payload = (await response.json()) as {
+    data?: {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      refresh_expires_in?: number;
+    };
+  };
+
+  const data = payload.data;
+  if (!data?.access_token || !data.refresh_token || !data.expires_in || !data.refresh_expires_in) {
+    logger.error(
+      { event: "tiktok.token.refresh_payload_invalid", payload, requestId, accountId: account._id.toHexString() },
+      "Unexpected TikTok refresh payload"
+    );
+    throw new Error("TikTok did not return refreshed credentials");
+  }
+
+  const encryptedAccess = tokenCipher.encrypt(data.access_token);
+  const encryptedRefresh = tokenCipher.encrypt(data.refresh_token);
+  const accessTokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
+  const refreshTokenExpiresAt = new Date(Date.now() + data.refresh_expires_in * 1000);
+  const accounts = db.collection<TikTokAccountRecord>("tiktok_accounts");
+  const users = db.collection("users");
+  const now = new Date();
+
+  await accounts.updateOne(
+    { _id: account._id },
+    {
+      $set: {
+        accessToken: {
+          keyId: tokenCipher.keyId,
+          ciphertext: encryptedAccess.ciphertext,
+          iv: encryptedAccess.iv,
+          authTag: encryptedAccess.authTag
+        },
+        refreshToken: {
+          keyId: tokenCipher.keyId,
+          ciphertext: encryptedRefresh.ciphertext,
+          iv: encryptedRefresh.iv,
+          authTag: encryptedRefresh.authTag
+        },
+        accessTokenExpiresAt,
+        refreshTokenExpiresAt,
+        updatedAt: now,
+        "syncMetadata.lastMetricsErrorAt": null
+      }
+    }
+  );
+
+  await users.updateOne(
+    { _id: account.userId },
+    {
+      $set: {
+        "tiktokAuth.keyId": tokenCipher.keyId,
+        "tiktokAuth.accessToken": encryptedAccess.ciphertext,
+        "tiktokAuth.accessTokenIv": encryptedAccess.iv,
+        "tiktokAuth.accessTokenTag": encryptedAccess.authTag,
+        "tiktokAuth.refreshToken": encryptedRefresh.ciphertext,
+        "tiktokAuth.refreshTokenIv": encryptedRefresh.iv,
+        "tiktokAuth.refreshTokenTag": encryptedRefresh.authTag,
+        "tiktokAuth.accessTokenExpiresAt": accessTokenExpiresAt,
+        "tiktokAuth.refreshTokenExpiresAt": refreshTokenExpiresAt,
+        "tiktokAuth.scope": account.scopes
+      }
+    }
+  );
+
+  account.accessToken = {
+    keyId: tokenCipher.keyId,
+    ciphertext: encryptedAccess.ciphertext,
+    iv: encryptedAccess.iv,
+    authTag: encryptedAccess.authTag
+  } as TikTokAccountRecord["accessToken"];
+  account.refreshToken = {
+    keyId: tokenCipher.keyId,
+    ciphertext: encryptedRefresh.ciphertext,
+    iv: encryptedRefresh.iv,
+    authTag: encryptedRefresh.authTag
+  } as TikTokAccountRecord["refreshToken"];
+  account.accessTokenExpiresAt = accessTokenExpiresAt;
+  account.refreshTokenExpiresAt = refreshTokenExpiresAt;
+
+  return { accessToken: data.access_token, account };
+};
+
+const callDisplayApi = async <T>(
+  path: string,
+  options: RequestInit,
+  logger: Logger,
+  requestId: string | undefined,
+  context: Record<string, unknown> = {}
+): Promise<T> => {
+  const url = `${DISPLAY_API_BASE_URL}${path}`;
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    const errorBody = await safeParseJson(response);
+    logger.error(
+      { event: "tiktok.display_api_error", status: response.status, body: errorBody, requestId, path, ...context },
+      "TikTok Display API request failed"
+    );
+    throw new Error(`TikTok Display API responded with status ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+};
+
+const fetchCreatorVideos = async (
+  accessToken: string,
+  logger: Logger,
+  requestId?: string
+): Promise<TikTokDisplayVideo[]> => {
+  const response = await callDisplayApi<TikTokVideoListResponse>(
+    DISPLAY_VIDEO_LIST_PATH,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`
+      },
+      body: JSON.stringify({
+        cursor: null,
+        max_count: PAGE_SIZE
+      })
+    },
+    logger,
+    requestId,
+    { operation: "video.list" }
+  );
+
+  if (response.error) {
+    logger.error(
+      { event: "tiktok.video.list_error", error: response.error, requestId },
+      "TikTok returned an error when listing videos"
+    );
+    throw new Error("TikTok returned an error when listing videos");
+  }
+
+  return response.data?.videos ?? [];
+};
+
+const fetchVideoMetrics = async (
+  accessToken: string,
+  videoIds: string[],
+  logger: Logger,
+  requestId?: string
+): Promise<Map<string, TikTokDisplayVideo["stats"]>> => {
+  if (videoIds.length === 0) {
+    return new Map();
+  }
+
+  const response = await callDisplayApi<TikTokVideoMetricsResponse>(
+    DISPLAY_VIDEO_DATA_PATH,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`
+      },
+      body: JSON.stringify({
+        video_ids: videoIds
+      })
+    },
+    logger,
+    requestId,
+    { operation: "video.data", count: videoIds.length }
+  );
+
+  if (response.error) {
+    logger.error(
+      { event: "tiktok.video.metrics_error", error: response.error, requestId },
+      "TikTok returned an error when fetching metrics"
+    );
+    throw new Error("TikTok returned an error when fetching metrics");
+  }
+
+  const metrics = new Map<string, TikTokDisplayVideo["stats"]>();
+  for (const entry of response.data?.metrics ?? []) {
+    if (entry.id) {
+      metrics.set(entry.id, entry.stats ?? {});
+    }
+  }
+
+  return metrics;
+};
+
+const publishVideoUpdate = async (
+  redis: IORedis,
+  accountId: string,
+  payload: Record<string, unknown>
+) => {
+  const channel = `${TIKTOK_VIDEO_UPDATE_CHANNEL}:${accountId}`;
+  await redis.publish(channel, JSON.stringify({ ...payload, accountId }));
+};
+
+export const createInitialSyncJobHandler = (options: {
+  refreshQueue: Queue<TikTokMetricsRefreshJob>;
+  redisPublisher: IORedis;
+  getMongoDb?: typeof getMongoDb;
+}) => {
+  const { refreshQueue, redisPublisher, getMongoDb: resolveMongoDb = getMongoDb } = options;
+
+  return async (job: Job<TikTokInitialSyncJob>) => {
+    const data = tiktokInitialSyncJobSchema.parse(job.data);
+    const logger = workerLogger.child({
+      jobId: job.id,
+      queue: job.queueName,
+      accountId: data.accountId,
+      requestId: data.requestId
+    });
+
+    const db = await resolveMongoDb();
+    const accounts = db.collection<TikTokAccountRecord>("tiktok_accounts");
+    const videosCollection = db.collection("videos");
+    const accountObjectId = new Types.ObjectId(data.accountId);
+    const account = await accounts.findOne({ _id: accountObjectId });
+
+    if (!account) {
+      logger.warn({ event: "tiktok.account.not_found" }, "TikTok account not found during initial sync");
+      return { status: "account_not_found" };
+    }
+
+    try {
+      const { accessToken } = await ensureValidAccessToken(account, db, logger, data.requestId);
+      const videos = await fetchCreatorVideos(accessToken, logger, data.requestId);
+      const now = new Date();
+      let upserted = 0;
+      let updated = 0;
+
+      for (const video of videos) {
+        try {
+          const operation = transformDisplayVideo(video, accountObjectId, now);
+          const update = {
+            $set: { ...operation.update.$set },
+            $setOnInsert: { ...operation.update.$setOnInsert }
+          } as typeof operation.update;
+
+          if (update.$set.postedAt === undefined) {
+            delete (update.$set as Record<string, unknown>).postedAt;
+          }
+
+          const result = await videosCollection.updateOne(operation.filter, update, { upsert: true });
+          if (result.upsertedCount && result.upsertedCount > 0) {
+            upserted += 1;
+          } else if (result.modifiedCount > 0) {
+            updated += 1;
+          }
+        } catch (error) {
+          logger.error(
+            { event: "tiktok.video.upsert_failed", videoId: video.id, error: (error as Error).message },
+            "Failed to upsert TikTok video"
+          );
+        }
+      }
+
+      await accounts.updateOne(
+        { _id: accountObjectId },
+        {
+          $set: {
+            "syncMetadata.lastVideoSyncAt": now,
+            "syncMetadata.lastMetricsRefreshAt": now,
+            updatedAt: now
+          }
+        }
+      );
+
+      await publishVideoUpdate(redisPublisher, data.accountId, {
+        event: "tiktok.videos.initial_sync",
+        videoCount: videos.length,
+        upserted,
+        updated,
+        requestId: data.requestId,
+        trigger: data.trigger
+      });
+
+      try {
+        await refreshQueue.add(
+          "metrics-refresh",
+          tiktokMetricsRefreshJobSchema.parse({
+            accountId: data.accountId,
+            reason: "scheduled",
+            requestId: data.requestId,
+            queuedAt: now.toISOString(),
+            retryCount: 0
+          }),
+          {
+            jobId: `${TIKTOK_REFRESH_QUEUE}:${data.accountId}`,
+            repeat: {
+              every: REFRESH_INTERVAL_MS
+            },
+            removeOnComplete: 50,
+            removeOnFail: 20
+          }
+        );
+      } catch (error) {
+        const message = (error as Error).message ?? "";
+        if (!message.includes("already exists")) {
+          throw error;
+        }
+
+        logger.debug(
+          { event: "tiktok.metrics.refresh_job_exists", accountId: data.accountId },
+          "Metrics refresh job already scheduled"
+        );
+      }
+
+      logger.info(
+        {
+          event: "tiktok.ingestion.completed",
+          requestId: data.requestId,
+          videos: videos.length,
+          upserted,
+          updated
+        },
+        "Completed TikTok initial sync"
+      );
+
+      return { videos: videos.length, upserted, updated };
+    } catch (error) {
+      const errorMessage = (error as Error).message;
+      await accounts.updateOne(
+        { _id: accountObjectId },
+        { $set: { "syncMetadata.lastMetricsErrorAt": new Date() } }
+      );
+
+      logger.error(
+        { event: "tiktok.ingestion.failed", error: errorMessage, requestId: data.requestId },
+        "TikTok initial sync failed"
+      );
+      throw error;
+    }
+  };
+};
+
+export const createMetricsRefreshJobHandler = (options: {
+  redisPublisher: IORedis;
+  getMongoDb?: typeof getMongoDb;
+}) => {
+  const { redisPublisher, getMongoDb: resolveMongoDb = getMongoDb } = options;
+
+  return async (job: Job<TikTokMetricsRefreshJob>) => {
+    const data = tiktokMetricsRefreshJobSchema.parse(job.data);
+    const logger = workerLogger.child({
+      jobId: job.id,
+      queue: job.queueName,
+      accountId: data.accountId,
+      requestId: data.requestId
+    });
+
+    const db = await resolveMongoDb();
+    const accounts = db.collection<TikTokAccountRecord>("tiktok_accounts");
+    const videosCollection = db.collection("videos");
+    const accountObjectId = new Types.ObjectId(data.accountId);
+    const account = await accounts.findOne({ _id: accountObjectId });
+
+    if (!account) {
+      logger.warn({ event: "tiktok.account.not_found" }, "TikTok account not found during metrics refresh");
+      return { status: "account_not_found" };
+    }
+
+    try {
+      const { accessToken } = await ensureValidAccessToken(account, db, logger, data.requestId);
+      const videoDocs = await videosCollection
+        .find({ ownerTikTokAccountId: accountObjectId })
+        .project<{ tiktokVideoId: string }>({ tiktokVideoId: 1 })
+        .toArray();
+
+      const videoIds = videoDocs.map((doc) => doc.tiktokVideoId).filter(Boolean);
+      let updated = 0;
+      const now = new Date();
+
+      for (const batch of chunkArray(videoIds, METRICS_BATCH_SIZE)) {
+        if (batch.length === 0) {
+          continue;
+        }
+
+        const metrics = await fetchVideoMetrics(accessToken, batch, logger, data.requestId);
+
+        for (const videoId of batch) {
+          const stats = sanitizeDisplayMetrics(metrics.get(videoId));
+          const update = {
+            $set: {
+              metrics: stats,
+              lastRefreshedAt: now,
+              updatedAt: now
+            }
+          };
+
+          const result = await videosCollection.updateOne({ tiktokVideoId: videoId }, update);
+          if (result.modifiedCount > 0) {
+            updated += 1;
+          }
+        }
+      }
+
+      await accounts.updateOne(
+        { _id: accountObjectId },
+        {
+          $set: {
+            "syncMetadata.lastMetricsRefreshAt": now,
+            "syncMetadata.lastMetricsErrorAt": null,
+            updatedAt: now
+          }
+        }
+      );
+
+      await publishVideoUpdate(redisPublisher, data.accountId, {
+        event: "tiktok.videos.metrics_refreshed",
+        updated,
+        total: videoIds.length,
+        requestId: data.requestId,
+        reason: data.reason
+      });
+
+      logger.info(
+        { event: "tiktok.metrics.refresh.completed", updated, total: videoIds.length, requestId: data.requestId },
+        "TikTok metrics refresh completed"
+      );
+
+      return { updated, total: videoIds.length };
+    } catch (error) {
+      const errorMessage = (error as Error).message;
+      await accounts.updateOne(
+        { _id: accountObjectId },
+        { $set: { "syncMetadata.lastMetricsErrorAt": new Date() } }
+      );
+
+      logger.error(
+        { event: "tiktok.metrics.refresh_failed", error: errorMessage, requestId: data.requestId },
+        "TikTok metrics refresh failed"
+      );
+      throw error;
+    }
+  };
+};

--- a/apps/worker/src/tiktok/transform.test.ts
+++ b/apps/worker/src/tiktok/transform.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Types } from "mongoose";
+import { sanitizeDisplayMetrics, transformDisplayVideo } from "./transform";
+
+test("transformDisplayVideo sanitizes and maps TikTok payloads", () => {
+  const now = new Date("2024-01-01T00:00:00.000Z");
+  const accountId = new Types.ObjectId();
+  const result = transformDisplayVideo(
+    {
+      id: "123",
+      description: "  A fun challenge video  ",
+      share_url: "https://www.tiktok.com/@creator/video/123",
+      embed_html:
+        '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123"></blockquote>',
+      create_time: 1_700_000_000,
+      author: {
+        username: "Creator",
+        display_name: "Creator"
+      },
+      stats: {
+        digg_count: 42.4,
+        comment_count: 7,
+        share_count: 2,
+        play_count: 99
+      }
+    },
+    accountId,
+    now
+  );
+
+  assert.equal(result.filter.tiktokVideoId, "123");
+  assert.equal(result.update.$set.shareUrl, "https://www.tiktok.com/@creator/video/123");
+  assert.equal(result.update.$set.caption, "A fun challenge video");
+  assert.equal(result.update.$set.ownerTikTokAccountId.toHexString(), accountId.toHexString());
+  assert.equal(result.update.$set.metrics.likeCount, 42);
+  assert.equal(result.update.$set.metrics.viewCount, 99);
+  assert.ok(result.update.$set.embed.html.includes("tiktok-embed"));
+  assert.deepEqual(result.update.$setOnInsert, {
+    tiktokVideoId: "123",
+    ownerTikTokAccountId: accountId,
+    createdAt: now
+  });
+});
+
+test("sanitizeDisplayMetrics normalizes undefined stats", () => {
+  const metrics = sanitizeDisplayMetrics(undefined);
+  assert.deepEqual(metrics, {
+    likeCount: 0,
+    commentCount: 0,
+    shareCount: 0,
+    viewCount: 0
+  });
+});

--- a/apps/worker/src/tiktok/transform.ts
+++ b/apps/worker/src/tiktok/transform.ts
@@ -1,0 +1,202 @@
+import { Types } from "mongoose";
+import {
+  tikTokEmbedHtmlSchema,
+  tikTokEmbedSchema,
+  videoMetricsSchema,
+  type TikTokEmbed
+} from "@trendpot/types";
+
+export interface TikTokDisplayAuthor {
+  open_id?: string;
+  display_name?: string;
+  avatar_url?: string;
+  username?: string;
+}
+
+export interface TikTokDisplayStats {
+  digg_count?: number;
+  comment_count?: number;
+  share_count?: number;
+  play_count?: number;
+  view_count?: number;
+}
+
+export interface TikTokDisplayVideo {
+  id: string;
+  create_time?: number;
+  description?: string;
+  embed_html?: string;
+  share_url?: string;
+  cover_image_url?: string;
+  author?: TikTokDisplayAuthor;
+  video?: { cover_image_url?: string };
+  stats?: TikTokDisplayStats;
+}
+
+export interface VideoUpsertOperation {
+  filter: { tiktokVideoId: string };
+  update: {
+    $set: {
+      ownerTikTokAccountId: Types.ObjectId;
+      shareUrl: string;
+      caption: string | null;
+      embed: TikTokEmbed;
+      postedAt?: Date;
+      metrics: {
+        likeCount: number;
+        commentCount: number;
+        shareCount: number;
+        viewCount: number;
+      };
+      lastRefreshedAt: Date;
+      updatedAt: Date;
+    };
+    $setOnInsert: {
+      tiktokVideoId: string;
+      ownerTikTokAccountId: Types.ObjectId;
+      createdAt: Date;
+    };
+  };
+}
+
+const sanitizeCaption = (value?: string | null): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.slice(0, 2200);
+};
+
+const sanitizeShareUrl = (value: string, username?: string | null): string => {
+  const trimmed = value?.trim();
+  if (trimmed) {
+    try {
+      const url = new URL(trimmed);
+      if (url.protocol === "https:" && url.hostname.includes("tiktok")) {
+        return url.toString();
+      }
+    } catch {
+      // fall back to deterministic URL below
+    }
+  }
+
+  if (username) {
+    return `https://www.tiktok.com/@${username}/video/${value}`;
+  }
+
+  return `https://www.tiktok.com/@trendpot/video/${value}`;
+};
+
+const buildAuthorUrl = (author?: TikTokDisplayAuthor): string | undefined => {
+  const username = author?.username ?? author?.open_id;
+  if (!username) {
+    return undefined;
+  }
+
+  return `https://www.tiktok.com/@${username}`;
+};
+
+const sanitizeEmbed = (
+  shareUrl: string,
+  embedHtml: string | undefined,
+  author?: TikTokDisplayAuthor,
+  thumbnailUrl?: string
+): TikTokEmbed => {
+  if (embedHtml) {
+    const parsedHtml = tikTokEmbedHtmlSchema.parse(embedHtml);
+    const sanitized = tikTokEmbedSchema.parse({
+      provider: "tiktok",
+      html: parsedHtml,
+      scriptUrl: "https://www.tiktok.com/embed.js",
+      width: undefined,
+      height: undefined,
+      thumbnailUrl,
+      authorName: author?.display_name ?? author?.username,
+      authorUrl: buildAuthorUrl(author)
+    });
+
+    return sanitized;
+  }
+
+  const fallbackHtml = `<blockquote class="tiktok-embed" cite="${shareUrl}" data-video-id="${shareUrl}"></blockquote>`;
+  const sanitized = tikTokEmbedSchema.parse({
+    provider: "tiktok",
+    html: fallbackHtml,
+    scriptUrl: "https://www.tiktok.com/embed.js",
+    width: undefined,
+    height: undefined,
+    thumbnailUrl,
+    authorName: author?.display_name ?? author?.username,
+    authorUrl: buildAuthorUrl(author)
+  });
+
+  return sanitized;
+};
+
+export const sanitizeDisplayMetrics = (stats: TikTokDisplayStats | undefined) =>
+  videoMetricsSchema.parse({
+    likeCount: Math.max(0, Math.trunc(stats?.digg_count ?? 0)),
+    commentCount: Math.max(0, Math.trunc(stats?.comment_count ?? 0)),
+    shareCount: Math.max(0, Math.trunc(stats?.share_count ?? 0)),
+    viewCount: Math.max(0, Math.trunc(stats?.play_count ?? stats?.view_count ?? 0))
+  });
+
+export const transformDisplayVideo = (
+  video: TikTokDisplayVideo,
+  accountId: Types.ObjectId,
+  now: Date
+): VideoUpsertOperation => {
+  if (!video.id) {
+    throw new Error("TikTok video payload is missing an id");
+  }
+
+  const username = video.author?.username ?? null;
+  const shareUrl = sanitizeShareUrl(video.share_url ?? video.id, username);
+  const metrics = sanitizeDisplayMetrics(video.stats);
+  const postedAt = video.create_time ? new Date(video.create_time * 1000) : undefined;
+  const embed = sanitizeEmbed(
+    shareUrl,
+    video.embed_html,
+    video.author,
+    video.cover_image_url ?? video.video?.cover_image_url
+  );
+
+  return {
+    filter: { tiktokVideoId: video.id },
+    update: {
+      $set: {
+        ownerTikTokAccountId: accountId,
+        shareUrl,
+        caption: sanitizeCaption(video.description),
+        embed,
+        postedAt,
+        metrics,
+        lastRefreshedAt: now,
+        updatedAt: now
+      },
+      $setOnInsert: {
+        tiktokVideoId: video.id,
+        ownerTikTokAccountId: accountId,
+        createdAt: now
+      }
+    }
+  };
+};
+
+export const chunkArray = <T>(values: T[], size: number): T[][] => {
+  if (size <= 0) {
+    return [values];
+  }
+
+  const chunks: T[][] = [];
+  for (let i = 0; i < values.length; i += size) {
+    chunks.push(values.slice(i, i + size));
+  }
+
+  return chunks;
+};

--- a/docs/design/tiktok-display-alignment.md
+++ b/docs/design/tiktok-display-alignment.md
@@ -1,0 +1,67 @@
+# TikTok Display API Alignment Notes
+
+## Purpose
+Product, compliance, and engineering agreed to fold the TikTok Display API ingestion requirements into the existing TikTok OAuth bridge so that creators authorize content sync in a single consent step. This document captures the decisions, secrets provisioning asks, and rate-limit expectations that unblock backend and worker implementation work.
+
+## OAuth Scope & Consent Decisions
+- **Unified consent:** We will request Display API scopes during the existing login flow so creators approve content ingestion alongside account access. No secondary consent screen is required.
+- **Scope bundle:**
+  - `user.info.basic` – required to correlate TikTok accounts with TrendPot creators.
+  - `video.list` – lists videos that can be ingested into submissions.
+  - `video.data` – fetches engagement metrics for refresh jobs.
+  - `webhook.subscription` – reserved for future webhook triggers; approved to include now to avoid another consent cycle.
+- **Consent copy:** Update the OAuth hand-off page to state that TrendPot will "ingest approved TikTok videos and refresh their metrics periodically" to satisfy compliance transparency guidance.
+- **Data minimization:** Only persist sanitized oEmbed payloads and metrics specified in the submissions schema; raw HTML/snippets must pass through the shared sanitizer before storage.
+
+## Token Storage & Key Management
+- **KMS alias:** `trendpot/tiktok-display-oauth` (AES-256-GCM). Ops to create in AWS KMS `us-east-1` with grants for `apps/api` and `apps/worker` service roles.
+- **Secrets manager entries:** Store encrypted client secret, webhook secret, and app signing secret in AWS Secrets Manager and expose them via environment variables listed below.
+- **Rotation policy:** Quarterly rotation for the client secret and webhook secret; tokens re-encrypted automatically during the next refresh cycle.
+
+## Environment Variables
+| Variable | Service(s) | Description |
+| --- | --- | --- |
+| `TIKTOK_CLIENT_KEY` | api, worker | Existing key reused for Display API; ensure value matches Display app ID. |
+| `TIKTOK_CLIENT_SECRET` | api | Pulled from Secrets Manager; decrypted at boot. |
+| `TIKTOK_DISPLAY_SCOPES` | api, web | Space-separated scopes requested during OAuth (`user.info.basic video.list video.data webhook.subscription`). |
+| `TIKTOK_DISPLAY_API_BASE_URL` | api, worker | Default `https://open-api.tiktok.com`. Allows staging overrides. |
+| `TIKTOK_DISPLAY_OAUTH_REDIRECT` | api, web | Overrides `TIKTOK_REDIRECT_URI` when Display scopes enabled (staging/prod variants). |
+| `TIKTOK_TOKEN_ENC_KEY_ID` | api, worker | Set to ARN of `trendpot/tiktok-display-oauth` key. |
+| `TIKTOK_WEBHOOK_SECRET` | api | HMAC secret for future webhook verification; provision now with random 32-byte value. |
+| `TIKTOK_INGESTION_PAGE_SIZE` | api, worker | Default `20`; controls page size for ingestion jobs. |
+| `TIKTOK_INGESTION_RATE_LIMIT_PER_MIN` | worker | Global throttle (see next section). |
+| `TIKTOK_INGESTION_RETRY_BACKOFF_MS` | worker | Base delay for exponential backoff when TikTok responds with 429/5xx. |
+| `TIKTOK_INGESTION_CONCURRENCY` | worker | Number of concurrent initial sync jobs (default `1`). |
+| `TIKTOK_REFRESH_CONCURRENCY` | worker | Number of concurrent metrics refresh jobs (default `1`). |
+| `TIKTOK_METRICS_REFRESH_INTERVAL_MS` | worker | Interval for recurring metrics refresh jobs (default `900000`). |
+| `TIKTOK_INGESTION_METRICS_BATCH_SIZE` | worker | Batch size for Display API metrics refresh (default `20`). |
+
+Ops should provision staging and production variants for all new variables and share the Secrets Manager ARNs in the internal credentials tracker.
+
+## Rate Limit & Telemetry Plan
+- **Display API baseline:** TikTok confirms a ceiling of **100 requests per minute** and **5,000 requests per day** per app. Worker ingestion must respect both.
+- **Throttle configuration:**
+  - Worker scheduler will cap concurrent API calls at 5 using BullMQ rate limiting.
+  - `TIKTOK_INGESTION_RATE_LIMIT_PER_MIN` defaults to `90` to leave headroom for manual retries and support diagnostics.
+  - Burst detection metrics exposed via OTel (`tiktok.display.rate_limit_exceeded`) with SLO alerts if more than 3 spikes/hour occur.
+- **Backoff policy:** Exponential backoff starting at `TIKTOK_INGESTION_RETRY_BACKOFF_MS` (default `5000`), doubling up to 5 attempts before marking a job as failed and notifying ops.
+
+## Token Lifecycle & Privacy Controls
+- **Encryption at rest:** Access and refresh tokens are encrypted with the KMS-backed `TikTokTokenCipher`. The cipher key ID is persisted with every credential so rotations can be enforced without downtime. Workers verify `keyId` before decrypting and surface `E_TIKTOK_KEY_MISMATCH` metrics if a stale key is detected.
+- **Lifecycle:**
+  - Access tokens are refreshed automatically when within 60 seconds of expiry; refresh tokens are rotated whenever TikTok issues a new secret.
+  - Mongo `tiktok_accounts` documents track the latest profile, video, and metrics sync timestamps plus the last error for operational visibility.
+  - User documents mirror encrypted token blobs to keep manual API requests (GraphQL, REST) in sync with worker refreshes.
+- **Deletion & revocation:** Manual revocation clears encrypted blobs from both the account and user document and publishes `tiktok.videos.update` events so caches prune submissions. Audit logs record the actor and reason for every revoke event.
+- **Access logging:** All token decryptions emit structured logs with `requestId`, `accountId`, and `operation` labels so compliance can reconcile usage during audits.
+
+## Privacy & Data Minimization Notes
+- **Sanitized embeds only:** Only sanitized oEmbed HTML that passes the shared Zod schema is persisted. Tests assert that script/style tags, inline handlers, `javascript:` URLs, and untrusted hosts are rejected before storage.
+- **Metrics scope:** Workers persist only aggregate counts (views, likes, comments, shares). Raw viewer data, author metadata beyond the embed, and private account fields are never stored.
+- **Red-team scenarios:** Automated tests cover malicious HTML payloads (script injection, onload, javascript URLs, hostile CDNs) and ensure the sanitizer rejects them. Additional tests validate the OAuth-to-ingestion queue hand-off and metrics refresh flow so regressions are caught before deployment.
+- **PII handling:** Creator display names and avatars are optional and sanitized to strip embedded markup; raw OAuth payloads are discarded after normalization.
+
+## Next Actions
+1. Ops to provision KMS alias, Secrets Manager entries, and environment variable scaffolding in staging & production.
+2. Product/compliance to review updated consent copy by end of week; frontend to implement wording change once approved.
+3. Backend to reference `TIKTOK_DISPLAY_SCOPES` when constructing OAuth URLs and begin implementing ingestion clients after ops confirms provisioning.

--- a/docs/runbooks/tiktok-ingestion.md
+++ b/docs/runbooks/tiktok-ingestion.md
@@ -1,0 +1,67 @@
+# TikTok Ingestion Runbook
+
+_Last updated: 2025-10-16_
+
+This runbook covers day-two operations for the TikTok Display API ingestion pipeline across the API and worker services. Follow these steps when provisioning environments, responding to incidents, or performing manual interventions.
+
+## 1. Prerequisites & Environment Variables
+- **KMS key:** `trendpot/tiktok-display-oauth` (AES-256-GCM). Confirm grants include the API and worker IAM roles.
+- **Secrets:** Ensure `TIKTOK_CLIENT_SECRET`, `TIKTOK_WEBHOOK_SECRET`, and `TIKTOK_TOKEN_ENC_KEY_ID` are sourced from AWS Secrets Manager. Rotate quarterly.
+- **Environment variables:**
+  - API: `TIKTOK_CLIENT_KEY`, `TIKTOK_CLIENT_SECRET`, `TIKTOK_REDIRECT_URI`, `TIKTOK_DISPLAY_SCOPES`, `TIKTOK_TOKEN_ENC_KEY_ID`.
+  - Worker: `TIKTOK_CLIENT_KEY`, `TIKTOK_INGESTION_PAGE_SIZE`, `TIKTOK_INGESTION_METRICS_BATCH_SIZE`, `TIKTOK_METRICS_REFRESH_INTERVAL_MS`, `TIKTOK_INGESTION_RATE_LIMIT_PER_MIN`, `TIKTOK_INGESTION_RETRY_BACKOFF_MS`, `TIKTOK_TOKEN_ENC_KEY_ID`.
+  - Shared: `MONGODB_URI`, `REDIS_URL`, `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+## 2. Linking Accounts (OAuth → Queue)
+1. Creator completes TikTok OAuth in the web app.
+2. API service encrypts tokens with the `TikTokTokenService` and upserts the `tiktok_accounts` document.
+3. API enqueues `tiktok:ingestion` job (`trigger=account_linked`).
+4. Verify enqueue in logs: `auth.tiktok.account_upserted` and `tiktok.ingestion.completed` with matching `requestId`.
+5. If the queue fails, retry by calling `POST /admin/tiktok/accounts/{id}/resync` (future endpoint) or enqueue manually via `apps/api/src/tiktok/tiktok-ingestion.queue.ts` script.
+
+## 3. Initial Sync Diagnostics
+- Worker fetches creator videos, sanitizes embeds, and upserts `videos` documents.
+- Successful runs publish `tiktok.videos.initial_sync` on Redis channel `tiktok:videos:update:<accountId>`.
+- Check Mongo:
+  ```bash
+  db.videos.find({ ownerTikTokAccountId: ObjectId("<accountId>") }).pretty()
+  ```
+- Common failure codes:
+  - `tiktok.display_api_error`: TikTok responded with non-200 status. Inspect `status` and `body` in logs.
+  - `tiktok.ingestion.failed`: Sanitization or persistence error. Review stack trace and retry after fixes.
+
+## 4. Metrics Refresh Monitoring
+- Metrics jobs repeat every `TIKTOK_METRICS_REFRESH_INTERVAL_MS` via BullMQ repeatable jobs.
+- Each run publishes `tiktok.videos.metrics_refreshed` payloads with `updated` and `total` counts.
+- Mongo `tiktok_accounts.syncMetadata.lastMetricsRefreshAt` and `lastMetricsErrorAt` track health. Alert if `lastMetricsErrorAt` is newer than refresh timestamp.
+- Metrics fetch uses rate limits defined by `TIKTOK_INGESTION_RATE_LIMIT_PER_MIN`; adjust cautiously to remain below TikTok quotas.
+
+## 5. Manual Refresh or Backfill
+1. Trigger a manual refresh by enqueuing a `tiktok:refresh` job:
+   ```ts
+   import { Queue } from "bullmq";
+   import { TIKTOK_REFRESH_QUEUE } from "@trendpot/types";
+
+   const queue = new Queue(TIKTOK_REFRESH_QUEUE, { connection: { host: "redis-host", port: 6379 } });
+   await queue.add("metrics-refresh", {
+     accountId: "<accountId>",
+     reason: "manual",
+     queuedAt: new Date().toISOString(),
+     requestId: `manual-${Date.now()}`
+   });
+   ```
+2. Confirm the job result in logs and Redis notifications.
+3. Update runbook notes with manual interventions for audit tracking.
+
+## 6. Incident Response
+- **Token refresh failures:** Look for `tiktok.token.refresh_failed` logs. Validate KMS access and TikTok client credentials. If refresh token expired, prompt creator to relink their account.
+- **Sanitizer rejections:** Workers throw `tiktok.ingestion.failed` with context. Ensure the backend sanitizer matches worker version; redeploy both if schema changed.
+- **Redis outage:** Queue processing pauses. Jobs retry automatically once Redis resumes. Manually resume by restarting worker pods if they exhausted retries.
+
+## 7. Compliance & Auditing
+- Retain audit logs for token issuance, refreshes, and manual revocations for at least 18 months.
+- Sanitization tests (`@trendpot/types` and worker/job integration tests) must stay green before deploying ingestion changes.
+- Document any manual data fixes or token rotations in the compliance tracker linked from `DEVELOPMENT_TRACKER.md`.
+
+---
+For questions or updates, ping #tiktok-ingestion in Slack and keep this runbook in sync with production changes.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch",
     "lint": "eslint \"src/**/*.ts\"",
-    "format": "prettier --check \"src/**/*.ts\""
+    "format": "prettier --check \"src/**/*.ts\"",
+    "test": "NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src"
   },
   "dependencies": {
     "zod": "3.23.4"

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -137,7 +137,9 @@ export const auditLogActionSchema = z.enum([
   "auth.session.revoke",
   "auth.profile.update",
   "security.settings.update",
-  "security.rate_limit.update"
+  "security.rate_limit.update",
+  "tiktok.video.list",
+  "tiktok.submission.create"
 ]);
 export type AuditLogAction = z.infer<typeof auditLogActionSchema>;
 

--- a/packages/types/src/challenges.ts
+++ b/packages/types/src/challenges.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { submissionConnectionSchema } from "./tiktok";
 
 export const challengeStatusSchema = z.enum(["draft", "live", "archived"]);
 
@@ -18,7 +19,8 @@ export const challengeSummaryListSchema = z.array(challengeSummarySchema);
 
 export const challengeSchema = challengeSummarySchema.extend({
   description: z.string(),
-  createdAt: z.string()
+  createdAt: z.string(),
+  submissions: submissionConnectionSchema.nullable().optional()
 });
 
 export const challengeStatusBreakdownSchema = z.object({

--- a/packages/types/src/graphql-client.ts
+++ b/packages/types/src/graphql-client.ts
@@ -176,6 +176,52 @@ const CHALLENGE_QUERY = /* GraphQL */ `
       version
       description
       createdAt
+      submissions {
+        edges {
+          cursor
+          node {
+            id
+            challengeId
+            creatorUserId
+            videoId
+            state
+            rejectionReason
+            createdAt
+            updatedAt
+            video {
+              id
+              tiktokVideoId
+              ownerAccountId
+              shareUrl
+              caption
+              postedAt
+              embed {
+                provider
+                html
+                scriptUrl
+                width
+                height
+                thumbnailUrl
+                authorName
+                authorUrl
+              }
+              metrics {
+                likeCount
+                commentCount
+                shareCount
+                viewCount
+              }
+              lastRefreshedAt
+              createdAt
+              updatedAt
+            }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
     }
   }
 `;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,3 +2,4 @@ export * from "./challenges";
 export * from "./leaderboard";
 export * from "./graphql-client";
 export * from "./auth";
+export * from "./tiktok";

--- a/packages/types/src/tiktok.sanitization.test.ts
+++ b/packages/types/src/tiktok.sanitization.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ZodError } from "zod";
+
+import { sanitizeTikTokEmbedHtml } from "./tiktok";
+
+describe("sanitizeTikTokEmbedHtml", () => {
+  const validEmbed = `  <blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123">
+    <section>
+      <a href="https://www.tiktok.com/@creator/video/123">Watch on TikTok</a>
+    </section>
+  </blockquote>`;
+
+  it("accepts valid TikTok embed HTML and trims whitespace", () => {
+    const sanitized = sanitizeTikTokEmbedHtml(validEmbed);
+    assert.equal(
+      sanitized,
+      '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123">\n    <section>\n      <a href="https://www.tiktok.com/@creator/video/123">Watch on TikTok</a>\n    </section>\n  </blockquote>'
+    );
+  });
+
+  it("rejects script tags", () => {
+    assert.throws(
+      () =>
+        sanitizeTikTokEmbedHtml(
+          '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123"><script>alert(1)</script></blockquote>'
+        ),
+      (error) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(error.message, /script or style tags/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects inline event handlers", () => {
+    assert.throws(
+      () =>
+        sanitizeTikTokEmbedHtml(
+          '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123"><section onload="alert(1)"></section></blockquote>'
+        ),
+      (error) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(error.message, /inline event handlers/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects javascript URLs", () => {
+    assert.throws(
+      () =>
+        sanitizeTikTokEmbedHtml(
+          '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123"><a href="javascript:alert(1)">bad</a></blockquote>'
+        ),
+      (error) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(error.message, /javascript: URLs/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects untrusted hosts in URL attributes", () => {
+    assert.throws(
+      () =>
+        sanitizeTikTokEmbedHtml(
+          '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@creator/video/123"><a href="https://evil.com/video">bad</a></blockquote>'
+        ),
+      (error) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(error.message, /untrusted URL/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects embeds missing the required container class", () => {
+    assert.throws(
+      () =>
+        sanitizeTikTokEmbedHtml(
+          '<blockquote cite="https://www.tiktok.com/@creator/video/123"><section><a href="https://www.tiktok.com/@creator/video/123">Watch</a></section></blockquote>'
+        ),
+      (error) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(error.message, /tiktok-embed container class/);
+        return true;
+      }
+    );
+  });
+
+  it("rejects embeds with untrusted cite URLs", () => {
+    assert.throws(
+      () =>
+        sanitizeTikTokEmbedHtml(
+          '<blockquote class="tiktok-embed" cite="https://evil.com/video/123"><section><a href="https://www.tiktok.com/@creator/video/123">Watch</a></section></blockquote>'
+        ),
+      (error) => {
+        assert.ok(error instanceof ZodError);
+        assert.match(error.message, /cite attribute must reference a trusted TikTok URL/);
+        return true;
+      }
+    );
+  });
+});

--- a/packages/types/src/tiktok.ts
+++ b/packages/types/src/tiktok.ts
@@ -1,0 +1,309 @@
+import { z } from "zod";
+
+const TIKTOK_EMBED_ALLOWED_TAGS = new Set([
+  "blockquote",
+  "section",
+  "a",
+  "p",
+  "span",
+  "strong",
+  "em",
+  "img",
+  "cite",
+  "iframe"
+]);
+
+const TIKTOK_TRUSTED_SCRIPT_URL = "https://www.tiktok.com/embed.js";
+
+const EMBED_HTML_MAX_LENGTH = 6000;
+
+const TIKTOK_TRUSTED_HOSTS = new Set([
+  "tiktok.com",
+  "www.tiktok.com",
+  "m.tiktok.com",
+  "vt.tiktok.com",
+  "vm.tiktok.com"
+]);
+
+const TIKTOK_TRUSTED_CDN_HOST_SUFFIXES = [
+  ".tiktokcdn.com",
+  ".tiktokcdn-us.com",
+  ".tiktokcdn-eu.com",
+  ".ttwstatic.com"
+];
+
+function isTrustedTikTokHost(url: URL): boolean {
+  if (TIKTOK_TRUSTED_HOSTS.has(url.host)) {
+    return true;
+  }
+
+  if (url.host.endsWith(".tiktok.com")) {
+    return true;
+  }
+
+  return false;
+}
+
+function isTrustedTikTokCdnHost(url: URL): boolean {
+  return TIKTOK_TRUSTED_CDN_HOST_SUFFIXES.some((suffix) => url.host.endsWith(suffix));
+}
+
+function isTrustedTikTokUrl(value: string, { allowCdn = false }: { allowCdn?: boolean } = {}): boolean {
+  try {
+    const url = new URL(value);
+
+    if (url.protocol !== "https:") {
+      return false;
+    }
+
+    if (isTrustedTikTokHost(url)) {
+      return true;
+    }
+
+    if (allowCdn && isTrustedTikTokCdnHost(url)) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function containsOnlyAllowedTags(html: string): boolean {
+  const tagRegex = /<\/?([a-z0-9:-]+)(?=\s|>|\/)/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRegex.exec(html)) !== null) {
+    const tagName = match[1].toLowerCase();
+    if (!TIKTOK_EMBED_ALLOWED_TAGS.has(tagName)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function assertTikTokEmbedHtml(html: string, ctx: z.RefinementCtx) {
+  if (html.length > EMBED_HTML_MAX_LENGTH) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_big,
+      type: "string",
+      maximum: EMBED_HTML_MAX_LENGTH,
+      inclusive: true,
+      message: "TikTok embed HTML exceeds the maximum allowed length."
+    });
+    return;
+  }
+
+  if (/<script\b/i.test(html) || /<style\b/i.test(html)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TikTok embed HTML cannot contain script or style tags."
+    });
+    return;
+  }
+
+  if (/\son[a-z]+\s*=\s*['\"][^'\"]*['\"]/i.test(html)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TikTok embed HTML cannot contain inline event handlers."
+    });
+    return;
+  }
+
+  if (/javascript:/i.test(html)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TikTok embed HTML cannot contain javascript: URLs."
+    });
+    return;
+  }
+
+  if (!containsOnlyAllowedTags(html)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TikTok embed HTML contains unsupported tags."
+    });
+    return;
+  }
+
+  if (!/(?:class|className)=(['\"])[^'\"]*\btiktok-embed\b[^'\"]*\1/i.test(html)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TikTok embed HTML must include the tiktok-embed container class."
+    });
+    return;
+  }
+
+  const citeMatch = html.match(/cite=(['\"])(.*?)\1/i);
+  if (!citeMatch || !isTrustedTikTokUrl(citeMatch[2])) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TikTok embed HTML cite attribute must reference a trusted TikTok URL."
+    });
+    return;
+  }
+
+  const urlAttrRegex = /\b(?:href|src)=(['\"])(.*?)\1/gi;
+  let urlMatch: RegExpExecArray | null;
+  while ((urlMatch = urlAttrRegex.exec(html)) !== null) {
+    const url = urlMatch[2];
+    const allowCdn = urlMatch[0].startsWith("src=");
+    if (!isTrustedTikTokUrl(url, { allowCdn })) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TikTok embed HTML references an untrusted URL."
+      });
+      return;
+    }
+  }
+}
+
+export const tikTokEmbedHtmlSchema = z
+  .string()
+  .trim()
+  .min(1, "TikTok embed HTML cannot be empty.")
+  .superRefine(assertTikTokEmbedHtml);
+
+export const sanitizeTikTokEmbedHtml = (html: string): string => tikTokEmbedHtmlSchema.parse(html);
+
+export const tikTokEmbedSchema = z.object({
+  provider: z.literal("tiktok"),
+  html: tikTokEmbedHtmlSchema,
+  scriptUrl: z.literal(TIKTOK_TRUSTED_SCRIPT_URL),
+  width: z.number().int().positive().max(2048).optional(),
+  height: z.number().int().positive().max(2048).optional(),
+  thumbnailUrl: z
+    .string()
+    .url()
+    .optional()
+    .refine((value) => (value ? isTrustedTikTokUrl(value, { allowCdn: true }) : true), {
+      message: "TikTok embed thumbnail URL must point to TikTok CDN."
+    }),
+  authorName: z.string().optional(),
+  authorUrl: z
+    .string()
+    .url()
+    .optional()
+    .refine((value) => (value ? isTrustedTikTokUrl(value) : true), {
+      message: "TikTok embed author URL must point to TikTok."
+    })
+});
+
+export const videoMetricsSchema = z.object({
+  likeCount: z.number().int().nonnegative(),
+  commentCount: z.number().int().nonnegative(),
+  shareCount: z.number().int().nonnegative(),
+  viewCount: z.number().int().nonnegative()
+});
+
+export const TIKTOK_INGESTION_QUEUE = "tiktok:ingestion" as const;
+export const TIKTOK_REFRESH_QUEUE = "tiktok:refresh" as const;
+export const TIKTOK_VIDEO_UPDATE_CHANNEL = "tiktok:videos:update" as const;
+
+export const tiktokInitialSyncJobSchema = z.object({
+  accountId: z.string().min(1, "TikTok account id is required."),
+  userId: z.string().min(1, "User id is required."),
+  trigger: z.enum(["account_linked", "manual", "retry"]),
+  requestId: z.string().min(1).optional(),
+  queuedAt: z.string().datetime()
+});
+
+export const tiktokMetricsRefreshJobSchema = z.object({
+  accountId: z.string().min(1, "TikTok account id is required."),
+  reason: z.enum(["scheduled", "manual", "backfill"]),
+  requestId: z.string().min(1).optional(),
+  queuedAt: z.string().datetime(),
+  retryCount: z.number().int().nonnegative().optional()
+});
+
+export type TikTokInitialSyncJob = z.infer<typeof tiktokInitialSyncJobSchema>;
+export type TikTokMetricsRefreshJob = z.infer<typeof tiktokMetricsRefreshJobSchema>;
+
+export const tikTokAccountSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  openId: z.string(),
+  username: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().url().nullable(),
+  scopes: z.array(z.string()),
+  accessTokenExpiresAt: z.string(),
+  refreshTokenExpiresAt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+
+export const videoSchema = z.object({
+  id: z.string(),
+  tiktokVideoId: z.string(),
+  ownerAccountId: z.string(),
+  shareUrl: z.string().url(),
+  caption: z.string().nullable(),
+  postedAt: z.string().nullable(),
+  embed: tikTokEmbedSchema,
+  metrics: videoMetricsSchema,
+  lastRefreshedAt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+
+export const videoEdgeSchema = z.object({
+  cursor: z.string(),
+  node: videoSchema
+});
+
+export const videoPageInfoSchema = z.object({
+  endCursor: z.string().nullable(),
+  hasNextPage: z.boolean()
+});
+
+export const videoConnectionSchema = z.object({
+  edges: z.array(videoEdgeSchema),
+  pageInfo: videoPageInfoSchema
+});
+
+export const submissionStateSchema = z.enum(["pending", "approved", "rejected", "removed"]);
+
+export const submissionSchema = z.object({
+  id: z.string(),
+  challengeId: z.string(),
+  creatorUserId: z.string(),
+  videoId: z.string(),
+  state: submissionStateSchema,
+  rejectionReason: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  video: videoSchema
+});
+
+export const submissionEdgeSchema = z.object({
+  cursor: z.string(),
+  node: submissionSchema
+});
+
+export const submissionPageInfoSchema = z.object({
+  endCursor: z.string().nullable(),
+  hasNextPage: z.boolean()
+});
+
+export const submissionConnectionSchema = z.object({
+  edges: z.array(submissionEdgeSchema),
+  pageInfo: submissionPageInfoSchema
+});
+
+export const submitToChallengeInputSchema = z.object({
+  challengeId: z.string(),
+  tiktokVideoId: z.string()
+});
+
+export type TikTokEmbed = z.infer<typeof tikTokEmbedSchema>;
+export type VideoMetrics = z.infer<typeof videoMetricsSchema>;
+export type TikTokAccount = z.infer<typeof tikTokAccountSchema>;
+export type Video = z.infer<typeof videoSchema>;
+export type VideoConnection = z.infer<typeof videoConnectionSchema>;
+export type SubmissionState = z.infer<typeof submissionStateSchema>;
+export type Submission = z.infer<typeof submissionSchema>;
+export type SubmissionConnection = z.infer<typeof submissionConnectionSchema>;
+export type SubmitToChallengeInput = z.infer<typeof submitToChallengeInputSchema>;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -21,3 +21,5 @@ export const withRetries = async <T>(fn: () => Promise<T>, options: RetryOptions
     }
   }
 };
+
+export * from "./tiktok-token-crypto";

--- a/packages/utils/src/tiktok-token-crypto.ts
+++ b/packages/utils/src/tiktok-token-crypto.ts
@@ -1,0 +1,97 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+
+export interface TikTokEncryptedSecret {
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+}
+
+export interface TikTokTokenCipherOptions {
+  /**
+   * Base64 encoded 32-byte key. When omitted we derive a deterministic
+   * development key from the session token secret to keep local bootstrap
+   * simple while still exercising the encryption path.
+   */
+  key?: string;
+  /**
+   * Optional secret used to derive a key when `key` is not supplied.
+   */
+  fallbackSecret?: string;
+  /**
+   * Identifier persisted alongside encrypted payloads so that rotation can
+   * verify callers are using a compatible key at decrypt time.
+   */
+  keyId?: string;
+}
+
+const DEFAULT_SESSION_SECRET = "trendpot-dev-session-token";
+const DEFAULT_KEY_ID = "local-dev";
+
+const decodeBase64 = (value: string): Buffer => {
+  try {
+    return Buffer.from(value, "base64");
+  } catch (error) {
+    throw new Error(`Failed to decode base64 value: ${(error as Error).message}`);
+  }
+};
+
+export class TikTokTokenCipher {
+  private readonly key: Buffer;
+
+  readonly keyId: string;
+
+  constructor(options: TikTokTokenCipherOptions = {}) {
+    const explicitKey = options.key ?? process.env.TIKTOK_TOKEN_ENC_KEY;
+    const fallbackSecret = options.fallbackSecret ?? process.env.AUTH_SESSION_TOKEN_SECRET ?? DEFAULT_SESSION_SECRET;
+    this.keyId = options.keyId ?? process.env.TIKTOK_TOKEN_ENC_KEY_ID ?? DEFAULT_KEY_ID;
+
+    if (explicitKey) {
+      const buffer = decodeBase64(explicitKey);
+      if (buffer.length !== 32) {
+        throw new Error("TikTok token encryption key must be 32 bytes when decoded from base64.");
+      }
+      this.key = buffer;
+      return;
+    }
+
+    this.key = createHash("sha256").update(fallbackSecret).digest();
+  }
+
+  encrypt(plaintext: string): TikTokEncryptedSecret {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", this.key, iv);
+    const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    return {
+      ciphertext: ciphertext.toString("base64"),
+      iv: iv.toString("base64"),
+      authTag: authTag.toString("base64")
+    };
+  }
+
+  decrypt(secret: TikTokEncryptedSecret, options: { keyId?: string } = {}): string {
+    if (options.keyId && options.keyId !== this.keyId) {
+      throw new Error("Encrypted payload was produced with a different key.");
+    }
+
+    const iv = decodeBase64(secret.iv);
+    const ciphertext = decodeBase64(secret.ciphertext);
+    const authTag = decodeBase64(secret.authTag);
+
+    const decipher = createDecipheriv("aes-256-gcm", this.key, iv);
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return decrypted.toString("utf8");
+  }
+}
+
+export const mapAccountTokenToEncryptedSecret = (
+  token: { ciphertext: string; iv: string; authTag?: string; tag?: string }
+): TikTokEncryptedSecret => ({
+  ciphertext: token.ciphertext,
+  iv: token.iv,
+  authTag: token.authTag ?? token.tag ?? ""
+});
+

--- a/test-shims/@nestjs/mongoose/index.js
+++ b/test-shims/@nestjs/mongoose/index.js
@@ -11,6 +11,9 @@ const SchemaFactory = {
             return undefined;
           }
         };
+      },
+      index() {
+        return this;
       }
     };
   }

--- a/test-shims/@tanstack/react-query/index.js
+++ b/test-shims/@tanstack/react-query/index.js
@@ -1,0 +1,45 @@
+const React = require("../../react");
+
+let currentClient = null;
+
+class QueryClient {
+  constructor() {
+    this.store = new Map();
+  }
+
+  setQueryData(key, value) {
+    this.store.set(JSON.stringify(key), value);
+  }
+
+  getQueryData(key) {
+    return this.store.get(JSON.stringify(key));
+  }
+}
+
+const QueryClientProvider = ({ client, children }) => {
+  currentClient = client;
+  const rendered = Array.isArray(children) ? children : [children];
+  return rendered.length === 1 ? rendered[0] : rendered;
+};
+
+const useQuery = (options) => {
+  if (!currentClient) {
+    throw new Error("QueryClientProvider is missing");
+  }
+  const data = currentClient.getQueryData(options.queryKey);
+  if (data !== undefined) {
+    return { data, isPending: false, isError: false, error: null, refetch: () => {}, isRefetching: false };
+  }
+  const value = options.queryFn ? options.queryFn() : undefined;
+  if (value instanceof Promise) {
+    throw new Error("Async query functions are not supported in this test shim");
+  }
+  currentClient.setQueryData(options.queryKey, value);
+  return { data: value, isPending: false, isError: false, error: null, refetch: () => {}, isRefetching: false };
+};
+
+module.exports = {
+  QueryClient,
+  QueryClientProvider,
+  useQuery
+};

--- a/test-shims/@trendpot/types/index.js
+++ b/test-shims/@trendpot/types/index.js
@@ -1,18 +1,313 @@
-class TrendPotGraphQLClient {
-  constructor() {
-    /* placeholder client for tests */
+const TIKTOK_EMBED_ALLOWED_TAGS = new Set([
+  "blockquote",
+  "section",
+  "a",
+  "p",
+  "span",
+  "strong",
+  "em",
+  "img",
+  "cite",
+  "iframe"
+]);
+
+const TIKTOK_TRUSTED_HOSTS = new Set([
+  "tiktok.com",
+  "www.tiktok.com",
+  "m.tiktok.com",
+  "vt.tiktok.com",
+  "vm.tiktok.com"
+]);
+
+const TIKTOK_TRUSTED_CDN_HOST_SUFFIXES = [
+  ".tiktokcdn.com",
+  ".tiktokcdn-us.com",
+  ".tiktokcdn-eu.com",
+  ".ttwstatic.com"
+];
+
+const EMBED_HTML_MAX_LENGTH = 6000;
+
+const isTrustedTikTokHost = (url) => {
+  if (TIKTOK_TRUSTED_HOSTS.has(url.host)) {
+    return true;
   }
-}
-const challengeLeaderboardSchema = {
-  parse(payload) {
-    if (!payload || typeof payload !== "object") {
-      throw new Error("Invalid payload");
+  if (url.host.endsWith(".tiktok.com")) {
+    return true;
+  }
+  return false;
+};
+
+const isTrustedTikTokCdnHost = (url) => TIKTOK_TRUSTED_CDN_HOST_SUFFIXES.some((suffix) => url.host.endsWith(suffix));
+
+const isTrustedTikTokUrl = (value, { allowCdn = false } = {}) => {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") {
+      return false;
     }
-    const leaders = Array.isArray(payload.leaders) ? payload.leaders : [];
+    if (isTrustedTikTokHost(url)) {
+      return true;
+    }
+    if (allowCdn && isTrustedTikTokCdnHost(url)) {
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+const containsOnlyAllowedTags = (html) => {
+  const tagRegex = /<\/?([a-z0-9:-]+)(?=\s|>|\/)/gi;
+  let match;
+  while ((match = tagRegex.exec(html)) !== null) {
+    const tagName = match[1].toLowerCase();
+    if (!TIKTOK_EMBED_ALLOWED_TAGS.has(tagName)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const parseEmbedHtml = (value) => {
+  if (typeof value !== "string") {
+    throw new Error("TikTok embed HTML must be a string.");
+  }
+  const html = value.trim();
+  if (!html) {
+    throw new Error("TikTok embed HTML cannot be empty.");
+  }
+  if (html.length > EMBED_HTML_MAX_LENGTH) {
+    throw new Error("TikTok embed HTML exceeds the maximum allowed length.");
+  }
+  if (/<script\b/i.test(html) || /<style\b/i.test(html)) {
+    throw new Error("TikTok embed HTML cannot contain script or style tags.");
+  }
+  if (/\son[a-z]+\s*=\s*['\"][^'\"]*['\"]/i.test(html)) {
+    throw new Error("TikTok embed HTML cannot contain inline event handlers.");
+  }
+  if (/javascript:/i.test(html)) {
+    throw new Error("TikTok embed HTML cannot contain javascript: URLs.");
+  }
+  if (!containsOnlyAllowedTags(html)) {
+    throw new Error("TikTok embed HTML contains unsupported tags.");
+  }
+  if (!/(?:class|className)=(['\"])[^'\"]*\btiktok-embed\b[^'\"]*\1/i.test(html)) {
+    throw new Error("TikTok embed HTML must include the tiktok-embed container class.");
+  }
+  const citeMatch = html.match(/cite=(['\"])(.*?)\1/i);
+  if (!citeMatch || !isTrustedTikTokUrl(citeMatch[2])) {
+    throw new Error("TikTok embed HTML cite attribute must reference a trusted TikTok URL.");
+  }
+  const urlAttrRegex = /\b(?:href|src)=(['\"])(.*?)\1/gi;
+  let urlMatch;
+  while ((urlMatch = urlAttrRegex.exec(html)) !== null) {
+    const url = urlMatch[2];
+    const allowCdn = urlMatch[0].startsWith("src=");
+    if (!isTrustedTikTokUrl(url, { allowCdn })) {
+      throw new Error("TikTok embed HTML references an untrusted URL.");
+    }
+  }
+  return html;
+};
+
+const tikTokEmbedHtmlSchema = {
+  parse: parseEmbedHtml
+};
+
+const sanitizeTikTokEmbedHtml = (html) => parseEmbedHtml(html);
+
+const tikTokEmbedSchema = {
+  parse(value) {
+    if (!value || typeof value !== "object") {
+      throw new Error("TikTok embed payload must be an object.");
+    }
+    if (value.provider !== "tiktok") {
+      throw new Error("TikTok embed provider must be 'tiktok'.");
+    }
+    const html = parseEmbedHtml(value.html);
+    if (value.scriptUrl !== "https://www.tiktok.com/embed.js") {
+      throw new Error("TikTok embed script URL must reference TikTok.");
+    }
+    if (value.thumbnailUrl && !isTrustedTikTokUrl(value.thumbnailUrl, { allowCdn: true })) {
+      throw new Error("TikTok embed thumbnail URL must point to TikTok CDN.");
+    }
+    if (value.authorUrl && !isTrustedTikTokUrl(value.authorUrl)) {
+      throw new Error("TikTok embed author URL must point to TikTok.");
+    }
     return {
-      generatedAt: typeof payload.generatedAt === "string" ? payload.generatedAt : new Date().toISOString(),
-      leaders
+      provider: "tiktok",
+      html,
+      scriptUrl: value.scriptUrl,
+      width: value.width,
+      height: value.height,
+      thumbnailUrl: value.thumbnailUrl,
+      authorName: value.authorName,
+      authorUrl: value.authorUrl
     };
   }
 };
-module.exports = { TrendPotGraphQLClient, challengeLeaderboardSchema };
+
+const videoMetricsSchema = {
+  parse(value) {
+    const toNumber = (num) => (typeof num === "number" && Number.isFinite(num) ? Math.max(0, Math.trunc(num)) : 0);
+    return {
+      likeCount: toNumber(value?.likeCount),
+      commentCount: toNumber(value?.commentCount),
+      shareCount: toNumber(value?.shareCount),
+      viewCount: toNumber(value?.viewCount)
+    };
+  }
+};
+
+const ensureString = (value, field) => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${field} is required.`);
+  }
+  return value;
+};
+
+const ensureEnum = (value, allowed, field) => {
+  if (!allowed.includes(value)) {
+    throw new Error(`${field} must be one of ${allowed.join(", ")}.`);
+  }
+  return value;
+};
+
+const ensureOptionalIso = (value, field) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${field} must be an ISO date string.`);
+  }
+  return value;
+};
+
+const ensureOptionalNumber = (value, field) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer.`);
+  }
+  return value;
+};
+
+const fanPermissions = Object.freeze([
+  "view_public_profile",
+  "initiate_donation",
+  "manage_own_sessions",
+  "update_own_profile"
+]);
+
+const creatorPermissions = Object.freeze([
+  ...fanPermissions,
+  "manage_own_challenges",
+  "view_own_donations",
+  "manage_own_submissions",
+  "manage_creator_profile"
+]);
+
+const operatorPermissions = Object.freeze([
+  ...creatorPermissions,
+  "view_all_donations",
+  "view_audit_logs",
+  "manage_sessions",
+  "flag_content",
+  "resolve_support_cases"
+]);
+
+const adminPermissions = Object.freeze([
+  ...operatorPermissions,
+  "manage_all_challenges",
+  "manage_roles",
+  "manage_payouts",
+  "manage_security_settings",
+  "manage_rate_limits"
+]);
+
+const rolePermissions = Object.freeze({
+  fan: fanPermissions,
+  creator: creatorPermissions,
+  operator: operatorPermissions,
+  admin: adminPermissions
+});
+
+const TIKTOK_INGESTION_QUEUE = "tiktok:ingestion";
+const TIKTOK_REFRESH_QUEUE = "tiktok:refresh";
+const TIKTOK_VIDEO_UPDATE_CHANNEL = "tiktok:videos:update";
+
+const tiktokInitialSyncJobSchema = {
+  parse(value) {
+    if (!value || typeof value !== "object") {
+      throw new Error("TikTok initial sync job must be an object.");
+    }
+    return {
+      accountId: ensureString(value.accountId, "TikTok account id"),
+      userId: ensureString(value.userId, "User id"),
+      trigger: ensureEnum(value.trigger, ["account_linked", "manual", "retry"], "trigger"),
+      requestId: value.requestId ? ensureString(value.requestId, "requestId") : undefined,
+      queuedAt: ensureString(value.queuedAt, "queuedAt")
+    };
+  }
+};
+
+const tiktokMetricsRefreshJobSchema = {
+  parse(value) {
+    if (!value || typeof value !== "object") {
+      throw new Error("TikTok metrics refresh job must be an object.");
+    }
+    return {
+      accountId: ensureString(value.accountId, "TikTok account id"),
+      reason: ensureEnum(value.reason, ["scheduled", "manual", "backfill"], "reason"),
+      requestId: value.requestId ? ensureString(value.requestId, "requestId") : undefined,
+      queuedAt: ensureString(value.queuedAt, "queuedAt"),
+      retryCount: ensureOptionalNumber(value.retryCount, "retryCount")
+    };
+  }
+};
+
+class GraphQLRequestError extends Error {
+  constructor(errors = []) {
+    super(errors.map((entry) => entry.message ?? String(entry)).join(" | "));
+    this.errors = errors;
+  }
+
+  get messages() {
+    return this.errors.map((entry) => entry.message ?? String(entry));
+  }
+}
+
+class TrendPotGraphQLClient {
+  constructor() {
+    this.store = new Map();
+  }
+
+  setChallenge(id, value) {
+    this.store.set(id, value);
+  }
+
+  async getChallenge(id) {
+    return this.store.get(id) ?? null;
+  }
+}
+
+module.exports = {
+  GraphQLRequestError,
+  TrendPotGraphQLClient,
+  tikTokEmbedHtmlSchema,
+  sanitizeTikTokEmbedHtml,
+  tikTokEmbedSchema,
+  videoMetricsSchema,
+  TIKTOK_INGESTION_QUEUE,
+  TIKTOK_REFRESH_QUEUE,
+  TIKTOK_VIDEO_UPDATE_CHANNEL,
+  tiktokInitialSyncJobSchema,
+  tiktokMetricsRefreshJobSchema,
+  rolePermissions
+};
+
+module.exports.default = module.exports;

--- a/test-shims/@trendpot/ui/index.js
+++ b/test-shims/@trendpot/ui/index.js
@@ -1,0 +1,7 @@
+const React = require("../../react");
+
+const Button = ({ children, ...props }) => {
+  return { type: "button", props: { ...props, children } };
+};
+
+module.exports = { Button };

--- a/test-shims/@trendpot/utils/index.js
+++ b/test-shims/@trendpot/utils/index.js
@@ -1,0 +1,58 @@
+const { createCipheriv, createDecipheriv, createHash, randomBytes } = require("node:crypto");
+
+class TikTokTokenCipher {
+  constructor(options = {}) {
+    const explicitKey = options.key ?? process.env.TIKTOK_TOKEN_ENC_KEY;
+    const fallbackSecret = options.fallbackSecret ?? process.env.AUTH_SESSION_TOKEN_SECRET ?? "trendpot-dev-session-token";
+    this.keyId = options.keyId ?? process.env.TIKTOK_TOKEN_ENC_KEY_ID ?? "local-dev";
+
+    if (explicitKey) {
+      const buffer = Buffer.from(explicitKey, "base64");
+      if (buffer.length !== 32) {
+        throw new Error("TikTok token encryption key must be 32 bytes when decoded from base64.");
+      }
+      this.key = buffer;
+    } else {
+      this.key = createHash("sha256").update(fallbackSecret).digest();
+    }
+  }
+
+  encrypt(plaintext) {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", this.key, iv);
+    const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    return {
+      ciphertext: ciphertext.toString("base64"),
+      iv: iv.toString("base64"),
+      authTag: authTag.toString("base64")
+    };
+  }
+
+  decrypt(secret, options = {}) {
+    if (options.keyId && options.keyId !== this.keyId) {
+      throw new Error("Encrypted payload was produced with a different key.");
+    }
+
+    const iv = Buffer.from(secret.iv, "base64");
+    const ciphertext = Buffer.from(secret.ciphertext, "base64");
+    const authTag = Buffer.from(secret.authTag ?? secret.tag ?? "", "base64");
+
+    const decipher = createDecipheriv("aes-256-gcm", this.key, iv);
+    if (authTag.length > 0) {
+      decipher.setAuthTag(authTag);
+    }
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return decrypted.toString("utf8");
+  }
+}
+
+const mapAccountTokenToEncryptedSecret = (token) => ({
+  ciphertext: token.ciphertext,
+  iv: token.iv,
+  authTag: token.authTag ?? token.tag ?? ""
+});
+
+module.exports = { TikTokTokenCipher, mapAccountTokenToEncryptedSecret };

--- a/test-shims/mongoose/index.js
+++ b/test-shims/mongoose/index.js
@@ -1,10 +1,30 @@
-module.exports = {
+class ObjectId {
+  constructor(value) {
+    this.value = value ?? "000000000000000000000000";
+  }
+
+  toHexString() {
+    return this.value;
+  }
+}
+
+const Types = {
+  ObjectId
+};
+
+const SchemaTypes = Types;
+
+const mongooseStub = {
   Schema: class Schema {},
   model() {
     return {};
   },
   connection: {},
-  Types: {
-    ObjectId: class ObjectId {}
-  }
+  Types,
+  SchemaTypes
 };
+
+module.exports = mongooseStub;
+module.exports.Types = Types;
+module.exports.SchemaTypes = SchemaTypes;
+module.exports.default = mongooseStub;

--- a/test-shims/pino/index.js
+++ b/test-shims/pino/index.js
@@ -1,0 +1,20 @@
+function createLogger() {
+  const logger = {
+    child() {
+      return logger;
+    },
+    info() {},
+    warn() {},
+    error() {},
+    debug() {}
+  };
+  return logger;
+}
+
+module.exports = function pino() {
+  return createLogger();
+};
+
+module.exports.stdTimeFunctions = {
+  isoTime: () => new Date().toISOString()
+};

--- a/test-shims/react-dom/server/index.js
+++ b/test-shims/react-dom/server/index.js
@@ -1,0 +1,41 @@
+const React = require("../../react");
+
+const renderNode = (node) => {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(renderNode).join("");
+  }
+  if (node.type === React.Fragment || node.type === Symbol.for("react.fragment")) {
+    return renderNode(node.props?.children);
+  }
+  if (typeof node.type === "function") {
+    return renderNode(node.type(node.props ?? {}));
+  }
+  const props = node.props ?? {};
+  const attrs = Object.entries(props)
+    .filter(([key, value]) => key !== "children" && key !== "dangerouslySetInnerHTML" && value !== false && value !== undefined)
+    .map(([key, value]) => {
+      if (value === true) {
+        return key;
+      }
+      return `${key}="${String(value)}"`;
+    })
+    .join(" ");
+  const openTag = attrs ? `<${node.type} ${attrs}>` : `<${node.type}>`;
+  if (props.dangerouslySetInnerHTML?.__html) {
+    return `${openTag}${props.dangerouslySetInnerHTML.__html}</${node.type}>`;
+  }
+  const children = renderNode(props.children);
+  return `${openTag}${children}</${node.type}>`;
+};
+
+module.exports = {
+  renderToString(element) {
+    return renderNode(element);
+  }
+};

--- a/test-shims/react/index.js
+++ b/test-shims/react/index.js
@@ -1,0 +1,29 @@
+const React = {
+  useState(initial) {
+    let state = typeof initial === "function" ? initial() : initial;
+    const setState = (value) => {
+      state = typeof value === "function" ? value(state) : value;
+    };
+    return [state, setState];
+  },
+  useEffect() {},
+  useMemo(fn) {
+    return fn();
+  },
+  useRef(initial = null) {
+    return { current: initial };
+  },
+  useContext() {
+    return null;
+  },
+  Fragment: Symbol.for("react.fragment")
+};
+
+module.exports = React;
+module.exports.default = React;
+module.exports.useState = React.useState;
+module.exports.useEffect = React.useEffect;
+module.exports.useMemo = React.useMemo;
+module.exports.useRef = React.useRef;
+module.exports.useContext = React.useContext;
+module.exports.Fragment = React.Fragment;

--- a/test-shims/react/jsx-runtime/index.js
+++ b/test-shims/react/jsx-runtime/index.js
@@ -1,0 +1,11 @@
+function createElement(type, props, key, isStaticChildren, source, self) {
+  const children = props?.children;
+  const rest = { ...props, children };
+  return { type, props: rest, children, key: key ?? null };
+}
+
+module.exports = {
+  jsx: createElement,
+  jsxs: createElement,
+  Fragment: Symbol.for("react.fragment")
+};

--- a/test-shims/ts-loader.mjs
+++ b/test-shims/ts-loader.mjs
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, access } from "node:fs/promises";
 import { dirname, resolve as resolvePath } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -14,7 +14,14 @@ const shimMap = new Map([
   ["@nestjs/platform-fastify", new URL("@nestjs/platform-fastify/index.js", shimBase).href],
   ["@fastify/cors", new URL("@fastify/cors/index.js", shimBase).href],
   ["mongoose", new URL("mongoose/index.js", shimBase).href],
-  ["@trendpot/types", new URL("@trendpot/types/index.js", shimBase).href]
+  ["@trendpot/types", new URL("@trendpot/types/index.js", shimBase).href],
+  ["@trendpot/utils", new URL("@trendpot/utils/index.js", shimBase).href],
+  ["pino", new URL("pino/index.js", shimBase).href],
+  ["react", new URL("react/index.js", shimBase).href],
+  ["react/jsx-runtime", new URL("react/jsx-runtime/index.js", shimBase).href],
+  ["react-dom/server", new URL("react-dom/server/index.js", shimBase).href],
+  ["@tanstack/react-query", new URL("@tanstack/react-query/index.js", shimBase).href],
+  ["@trendpot/ui", new URL("@trendpot/ui/index.js", shimBase).href]
 ]);
 
 /**
@@ -25,9 +32,15 @@ export async function resolve(specifier, context, defaultResolve) {
   if (specifier.startsWith("./") || specifier.startsWith("../")) {
     const parentUrl = context.parentURL ?? "file://";
     const resolved = new URL(specifier, parentUrl);
-    if (!resolved.pathname.endsWith(".ts") && !resolved.pathname.endsWith(".js")) {
-      const tsUrl = new URL(`${specifier}.ts`, parentUrl);
-      return { url: tsUrl.href, shortCircuit: true };
+    if (!resolved.pathname.endsWith(".ts") && !resolved.pathname.endsWith(".tsx") && !resolved.pathname.endsWith(".js")) {
+      const tsxUrl = new URL(`${specifier}.tsx`, parentUrl);
+      try {
+        await access(tsxUrl);
+        return { url: tsxUrl.href, shortCircuit: true };
+      } catch {
+        const tsUrl = new URL(`${specifier}.ts`, parentUrl);
+        return { url: tsUrl.href, shortCircuit: true };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- document TikTok ingestion security/QA expectations and add a runbook for KMS usage, refresh cadence, and incident response
- expand the TikTok embed sanitizer test coverage and introduce API, worker, and web integration suites validating queue handoffs and rendering
- add lightweight React/React Query/pino/mongoose shims plus queue tweaks so the integration tests run headlessly against sanitized data

## Testing
- `NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test packages/types/src/tiktok.sanitization.test.ts`
- `NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test apps/api/src/platform-auth/platform-auth.integration.test.ts`
- `NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test apps/worker/src/tiktok/tiktok-jobs.integration.test.ts`
- `NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test apps/web/src/components/challenges/challenge-detail.integration.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d5b068bad0832eae4986b5d2430065