### PR TITLE
Ensure TikTok OpenSDK loads before login

### DIFF
--- a/apps/web/src/components/auth/login-form.tsx
+++ b/apps/web/src/components/auth/login-form.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { Button, Card, CardContent, CardFooter, CardHeader } from "@trendpot/ui";
 import { startTikTokLogin } from "@/lib/auth-client";
-import { launchTikTokLogin } from "@/lib/tiktok-open-sdk";
+import { launchTikTokLogin, loadTikTokOpenSDK } from "@/lib/tiktok-open-sdk";
 
 function resolveDeviceLabel() {
   if (typeof navigator === "undefined") {
@@ -29,6 +29,8 @@ export function LoginForm({ nextPath }: LoginFormProps) {
     mutationFn: async () => {
       setStatus("Contacting TikTok…");
       const { intent } = await startTikTokLogin({ returnPath: nextPath, deviceLabel });
+      setStatus("Preparing TikTok login…");
+      await loadTikTokOpenSDK(intent.clientKey);
       setStatus("Redirecting to TikTok…");
       await launchTikTokLogin(intent);
     },

--- a/apps/web/src/components/auth/signup-form.tsx
+++ b/apps/web/src/components/auth/signup-form.tsx
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { Button, Card, CardContent, CardFooter, CardHeader } from "@trendpot/ui";
 import { startTikTokLogin } from "@/lib/auth-client";
-import { launchTikTokLogin } from "@/lib/tiktok-open-sdk";
+import { launchTikTokLogin, loadTikTokOpenSDK } from "@/lib/tiktok-open-sdk";
 
 function resolveDeviceLabel() {
   if (typeof navigator === "undefined") {
@@ -29,6 +29,8 @@ export function SignupForm({ nextPath }: SignupFormProps) {
     mutationFn: async () => {
       setStatus("Contacting TikTok…");
       const { intent } = await startTikTokLogin({ returnPath: nextPath, deviceLabel });
+      setStatus("Preparing TikTok signup…");
+      await loadTikTokOpenSDK(intent.clientKey);
       setStatus("Redirecting to TikTok…");
       await launchTikTokLogin(intent);
     },

--- a/apps/web/src/lib/tiktok-open-sdk.ts
+++ b/apps/web/src/lib/tiktok-open-sdk.ts
@@ -1,5 +1,9 @@
 const SDK_FALLBACK_ERROR =
   "TikTok OpenSDK is not available. Ensure the SDK script has loaded before launching login.";
+const SDK_LOAD_ERROR =
+  "We couldn't load TikTok's login tools. Please check your connection and try again.";
+const SDK_SCRIPT_URL = "https://www.tiktok.com/auth/opensdk.js";
+const SDK_SCRIPT_SELECTOR = 'script[data-tiktok-open-sdk="true"]';
 
 interface TikTokLoginIntent {
   state: string;
@@ -16,6 +20,8 @@ type TikTokLoginInvoker = (options: {
   state: string;
   scope?: string;
 }) => MaybePromise<unknown>;
+
+let sdkLoadPromise: Promise<void> | null = null;
 
 function resolveInvoker(): TikTokLoginInvoker | null {
   if (typeof window === "undefined") {
@@ -50,7 +56,73 @@ function resolveInvoker(): TikTokLoginInvoker | null {
   return null;
 }
 
+export function loadTikTokOpenSDK(clientKey: string) {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return Promise.resolve();
+  }
+
+  if (resolveInvoker()) {
+    return Promise.resolve();
+  }
+
+  const existingScript = document.querySelector<HTMLScriptElement>(SDK_SCRIPT_SELECTOR);
+
+  if (existingScript?.dataset.status === "ready") {
+    return Promise.resolve();
+  }
+
+  if (sdkLoadPromise) {
+    return sdkLoadPromise;
+  }
+
+  sdkLoadPromise = new Promise<void>((resolve, reject) => {
+    const script = existingScript ?? document.createElement("script");
+
+    const handleResolve = () => {
+      script.dataset.status = "ready";
+      script.removeEventListener("load", handleResolve);
+      script.removeEventListener("error", handleReject);
+      resolve();
+    };
+
+    const handleReject = () => {
+      script.dataset.status = "error";
+      script.removeEventListener("load", handleResolve);
+      script.removeEventListener("error", handleReject);
+
+      if (!existingScript && script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+
+      sdkLoadPromise = null;
+      reject(new Error(SDK_LOAD_ERROR));
+    };
+
+    script.addEventListener("load", handleResolve);
+    script.addEventListener("error", handleReject);
+
+    if (!existingScript) {
+      script.async = true;
+      script.defer = true;
+      script.src = `${SDK_SCRIPT_URL}?clientKey=${encodeURIComponent(clientKey)}`;
+      script.setAttribute("data-tiktok-open-sdk", "true");
+      script.dataset.status = "loading";
+      document.head.appendChild(script);
+    } else if (script.dataset.status !== "loading") {
+      script.dataset.status = "loading";
+    }
+
+    if ((script as { readyState?: string }).readyState === "complete") {
+      handleResolve();
+    }
+  });
+
+  return sdkLoadPromise;
+}
+
 export async function launchTikTokLogin(intent: TikTokLoginIntent) {
+  await loadTikTokOpenSDK(intent.clientKey);
+
   const invoker = resolveInvoker();
 
   if (!invoker) {


### PR DESCRIPTION
## Plan
- Add a singleton loader for the TikTok OpenSDK script
- Update auth flows to wait for the loader before invoking TikTok login

## Summary
- Add a reusable loader that appends the official TikTok OpenSDK script and exposes a friendly error when it fails
- Ensure `launchTikTokLogin` and the login/signup forms await the loader so the SDK is ready before calling into it

## Testing
- pnpm --filter web lint *(fails: Next CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d93a7222f8832ea1d509fd236d1c82