### PR TITLE
Handle paginated TikTok ingestion and extend coverage

### DIFF
--- a/apps/api/src/tiktok/tiktok.service.test.ts
+++ b/apps/api/src/tiktok/tiktok.service.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Types } from "mongoose";
+import type { Logger } from "pino";
+
+import type { AuthenticatedUser } from "../auth/auth.types";
+import { TikTokDisplayService } from "./tiktok.service";
+
+const encodeCursor = (payload: { postedAt: Date; id: Types.ObjectId; apiCursor?: string | null }) => {
+  return Buffer.from(
+    JSON.stringify({
+      postedAt: payload.postedAt.toISOString(),
+      id: payload.id.toHexString(),
+      apiCursor: payload.apiCursor ?? null
+    })
+  ).toString("base64");
+};
+
+const decodeCursor = (cursor: string) => {
+  return JSON.parse(Buffer.from(cursor, "base64").toString("utf8")) as {
+    postedAt: string;
+    id: string;
+    apiCursor: string | null;
+  };
+};
+
+const createLoggerStub = (): Logger => {
+  const stub: any = {
+    level: "info",
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    trace: () => undefined,
+    fatal: () => undefined
+  };
+
+  stub.child = () => stub;
+
+  return stub as Logger;
+};
+
+test("listCreatorVideos paginates TikTok responses and encodes next cursor", async () => {
+  const accountId = new Types.ObjectId();
+  const account = {
+    _id: accountId,
+    openId: "creator-open-id",
+    username: "creator",
+    accessToken: { keyId: "key" },
+    refreshToken: { keyId: "key" }
+  };
+
+  const accountFindCalls: unknown[] = [];
+  const accountUpdateCalls: Array<{ filter: unknown; update: unknown }> = [];
+
+  const accountModel = {
+    findOne(filter: unknown) {
+      accountFindCalls.push(filter);
+      return {
+        async exec() {
+          return account;
+        }
+      };
+    },
+    updateOne(filter: unknown, update: unknown) {
+      accountUpdateCalls.push({ filter, update });
+      return {
+        async exec() {
+          return { acknowledged: true };
+        }
+      };
+    }
+  };
+
+  const auditLogs: unknown[] = [];
+  const auditLogModel = {
+    async create(payload: unknown) {
+      auditLogs.push(payload);
+    }
+  };
+
+  const rateLimitService = {
+    async consume() {
+      return { allowed: true };
+    }
+  };
+
+  const service = new TikTokDisplayService(
+    {} as never,
+    accountModel as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    auditLogModel as never,
+    {} as never,
+    rateLimitService as never
+  );
+
+  const callRequests: Array<{ cursor: string | null; max_count: number }> = [];
+  const persistedVideos: string[] = [];
+  const apiPages = [
+    {
+      videos: [
+        { id: "video-1", description: "first" },
+        { id: "video-2", description: "second" }
+      ],
+      cursor: "cursor-a",
+      has_more: true
+    },
+    {
+      videos: [
+        { id: "video-3", description: "third" },
+        { id: "video-4", description: "fourth" }
+      ],
+      cursor: "cursor-b",
+      has_more: true
+    }
+  ];
+
+  Reflect.set(service as any, "ensureValidAccessToken", async () => "access-token");
+  Reflect.set(service as any, "callDisplayApi", async (_path: string, init: RequestInit) => {
+    const body = JSON.parse(String(init.body)) as { cursor: string | null; max_count: number };
+    callRequests.push({ cursor: body.cursor, max_count: body.max_count });
+    const page = apiPages.shift() ?? { videos: [], cursor: null, has_more: false };
+    return {
+      data: {
+        videos: page.videos,
+        cursor: page.cursor,
+        has_more: page.has_more
+      }
+    };
+  });
+  Reflect.set(service as any, "upsertVideoFromDisplay", async (_account: unknown, video: { id: string }) => {
+    persistedVideos.push(video.id);
+  });
+
+  const lastDocId = new Types.ObjectId();
+  let buildArgs: {
+    accountId: unknown;
+    limit: number;
+    cursor: unknown;
+    options: { apiHasMore: boolean; nextApiCursor: string | null } | undefined;
+  } | null = null;
+
+  Reflect.set(
+    service as any,
+    "buildVideoConnection",
+    async (
+      accountIdArg: unknown,
+      limitArg: number,
+      cursorArg: unknown,
+      optionsArg: { apiHasMore: boolean; nextApiCursor: string | null } | undefined
+    ) => {
+      buildArgs = { accountId: accountIdArg, limit: limitArg, cursor: cursorArg, options: optionsArg };
+      return {
+        edges: [
+          {
+            cursor: encodeCursor({ postedAt: new Date("2024-03-01T00:00:00Z"), id: lastDocId }),
+            node: { id: "video-node" }
+          }
+        ],
+        pageInfo: {
+          endCursor: encodeCursor({
+            postedAt: new Date("2024-03-02T00:00:00Z"),
+            id: lastDocId,
+            apiCursor: optionsArg?.nextApiCursor ?? null
+          }),
+          hasNextPage: Boolean(optionsArg?.apiHasMore)
+        }
+      };
+    }
+  );
+
+  const user = {
+    id: new Types.ObjectId().toHexString(),
+    roles: ["creator"],
+    tiktokUserId: "creator-open-id"
+  } as unknown as AuthenticatedUser;
+
+  const previousCursor = encodeCursor({
+    postedAt: new Date("2024-02-01T00:00:00Z"),
+    id: new Types.ObjectId(),
+    apiCursor: "cursor-prev"
+  });
+
+  const logger = createLoggerStub();
+
+  const result = await service.listCreatorVideos({
+    user,
+    first: 4,
+    after: previousCursor,
+    logger,
+    requestId: "req-123"
+  });
+
+  assert.equal(callRequests.length, 2);
+  assert.deepEqual(callRequests[0], { cursor: "cursor-prev", max_count: 4 });
+  assert.deepEqual(callRequests[1], { cursor: "cursor-a", max_count: 2 });
+
+  assert.deepEqual(persistedVideos, ["video-1", "video-2", "video-3", "video-4"]);
+
+  assert.ok(buildArgs);
+  assert.equal(String((buildArgs as any).accountId), String(accountId));
+  assert.equal(buildArgs?.limit, 4);
+  assert.equal((buildArgs?.cursor as { apiCursor: string | null } | undefined)?.apiCursor, "cursor-prev");
+  assert.equal(buildArgs?.options?.apiHasMore, true);
+  assert.equal(buildArgs?.options?.nextApiCursor, "cursor-b");
+
+  const pageInfoPayload = decodeCursor(result.pageInfo.endCursor ?? "");
+  assert.equal(pageInfoPayload.apiCursor, "cursor-b");
+  assert.equal(result.pageInfo.hasNextPage, true);
+
+  assert.equal(accountFindCalls.length, 1);
+  assert.equal(accountUpdateCalls.length, 1);
+  assert.equal(auditLogs.length, 1);
+  assert.match((auditLogs[0] as { context: { summary: string } }).context.summary, /Fetched 4 TikTok videos/);
+});

--- a/apps/api/src/tiktok/tiktok.service.ts
+++ b/apps/api/src/tiktok/tiktok.service.ts
@@ -123,26 +123,64 @@ export class TikTokDisplayService {
     const limit = sanitizePageSize(first);
     const cursor = decodeVideoCursor(after);
 
-    const response = await this.callDisplayApi<TikTokDisplayListResponse>(
-      DISPLAY_VIDEO_LIST_PATH,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`
-        },
-        body: JSON.stringify({
-          cursor: null,
-          max_count: limit
-        })
-      },
-      { rateLimitKey: "video_list", logger, requestId }
-    );
+    let apiCursor = cursor?.apiCursor ?? null;
+    let totalFetched = 0;
+    let totalPersisted = 0;
+    let apiHasMore = false;
+    let nextApiCursor: string | null = null;
+    const seenCursors = new Set<string>();
 
-    const videos = response.data?.videos ?? [];
-    await Promise.all(
-      videos.map((video) => this.upsertVideoFromDisplay(account, video, logger, requestId))
-    );
+    do {
+      const remaining = limit - totalFetched;
+      const pageSize = Math.min(PAGE_SIZE, Math.max(1, remaining));
+      const response = await this.callDisplayApi<TikTokDisplayListResponse>(
+        DISPLAY_VIDEO_LIST_PATH,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`
+          },
+          body: JSON.stringify({
+            cursor: apiCursor ?? null,
+            max_count: pageSize
+          })
+        },
+        { rateLimitKey: "video_list", logger, requestId }
+      );
+
+      const videos = response.data?.videos ?? [];
+      totalFetched += videos.length;
+
+      if (videos.length > 0) {
+        await Promise.all(
+          videos.map((video) => this.upsertVideoFromDisplay(account, video, logger, requestId))
+        );
+        totalPersisted += videos.length;
+      }
+
+      const responseCursor = response.data?.cursor ?? null;
+      apiHasMore = Boolean(response.data?.has_more && responseCursor);
+
+      if (apiHasMore) {
+        nextApiCursor = responseCursor;
+        const cursorKey = responseCursor ?? "";
+        if (seenCursors.has(cursorKey)) {
+          logger.warn(
+            { event: "tiktok.video.duplicate_cursor", requestId, cursor: responseCursor },
+            "TikTok returned a duplicate cursor; stopping pagination"
+          );
+          apiHasMore = false;
+          nextApiCursor = null;
+          break;
+        }
+        seenCursors.add(cursorKey);
+      } else {
+        nextApiCursor = null;
+      }
+
+      apiCursor = responseCursor;
+    } while (apiHasMore && totalFetched < limit);
 
     await this.accountModel
       .updateOne(
@@ -151,14 +189,17 @@ export class TikTokDisplayService {
       )
       .exec();
 
-    const connection = await this.buildVideoConnection(account._id, limit, cursor);
+    const connection = await this.buildVideoConnection(account._id, limit, cursor, {
+      apiHasMore,
+      nextApiCursor
+    });
 
     await this.recordAuditLog({
       user,
       action: "tiktok.video.list",
       logger,
       requestId,
-      summary: `Fetched ${videos.length} TikTok videos for review.`
+      summary: `Fetched ${totalPersisted} TikTok videos for review.`
     });
 
     return connection;
@@ -510,7 +551,8 @@ export class TikTokDisplayService {
   private async buildVideoConnection(
     accountId: Types.ObjectId,
     limit: number,
-    cursor: ReturnType<typeof decodeVideoCursor>
+    cursor: ReturnType<typeof decodeVideoCursor>,
+    options?: { apiHasMore: boolean; nextApiCursor: string | null }
   ): Promise<VideoConnectionResult> {
     const conditions: Record<string, unknown>[] = [{ ownerTikTokAccountId: accountId }];
 
@@ -532,17 +574,32 @@ export class TikTokDisplayService {
       .populate({ path: "ownerTikTokAccountId", model: TikTokAccountEntity.name })
       .exec();
 
-    const hasNextPage = documents.length > limit;
-    const window = hasNextPage ? documents.slice(0, -1) : documents;
+    const apiHasMore = options?.apiHasMore ?? false;
+    const hasMoreDocs = documents.length > limit;
+    const hasNextPage = hasMoreDocs || apiHasMore;
+    const window = hasMoreDocs ? documents.slice(0, -1) : documents;
 
     const edges = window.map((doc) => {
       const owner = doc.ownerTikTokAccountId as unknown as TikTokAccountDocument;
       const node = toVideoNode(doc, owner);
-      const edgeCursor = encodeVideoCursor(doc.postedAt ?? doc.createdAt ?? new Date(), doc._id);
+      const edgeCursor = encodeVideoCursor({
+        postedAt: doc.postedAt ?? doc.createdAt ?? new Date(),
+        id: doc._id
+      });
       return { cursor: edgeCursor, node };
     });
 
-    const endCursor = edges.length > 0 ? edges[edges.length - 1]?.cursor ?? null : null;
+    let endCursor: string | null = null;
+    if (edges.length > 0) {
+      const lastDoc = window[window.length - 1];
+      const lastCursor = lastDoc?.postedAt ?? lastDoc?.createdAt ?? new Date();
+      const lastId = lastDoc?._id ?? new Types.ObjectId();
+      endCursor = encodeVideoCursor({
+        postedAt: lastCursor,
+        id: lastId,
+        apiCursor: apiHasMore ? options?.nextApiCursor ?? null : null
+      });
+    }
 
     return {
       edges,
@@ -715,27 +772,55 @@ const buildEmbed = (shareUrl: string, embedHtml?: string, username?: string | nu
   };
 };
 
-const encodeVideoCursor = (postedAt: Date, id: Types.ObjectId): string => {
-  return Buffer.from(`${postedAt.toISOString()}::${id.toHexString()}`).toString("base64");
+const encodeVideoCursor = (params: { postedAt: Date; id: Types.ObjectId; apiCursor?: string | null }): string => {
+  const payload = {
+    postedAt: params.postedAt.toISOString(),
+    id: params.id.toHexString(),
+    apiCursor: params.apiCursor ?? null
+  } satisfies { postedAt: string; id: string; apiCursor: string | null };
+
+  return Buffer.from(JSON.stringify(payload)).toString("base64");
 };
 
-const decodeVideoCursor = (cursor?: string): { postedAt: Date; id: Types.ObjectId } | null => {
+const decodeVideoCursor = (
+  cursor?: string
+): { postedAt: Date; id: Types.ObjectId; apiCursor: string | null } | null => {
   if (!cursor) {
     return null;
   }
 
   try {
     const raw = Buffer.from(cursor, "base64").toString("utf8");
-    const [postedAtIso, idHex] = raw.split("::");
-    const postedAt = new Date(postedAtIso);
-    if (!postedAtIso || Number.isNaN(postedAt.getTime()) || !idHex) {
-      return null;
-    }
 
-    return {
-      postedAt,
-      id: new Types.ObjectId(idHex)
-    };
+    try {
+      const parsed = JSON.parse(raw) as { postedAt?: string; id?: string; apiCursor?: string | null };
+      if (!parsed?.postedAt || !parsed.id) {
+        throw new Error("invalid payload");
+      }
+
+      const postedAt = new Date(parsed.postedAt);
+      if (Number.isNaN(postedAt.getTime())) {
+        throw new Error("invalid date");
+      }
+
+      return {
+        postedAt,
+        id: new Types.ObjectId(parsed.id),
+        apiCursor: parsed.apiCursor ?? null
+      };
+    } catch {
+      const [postedAtIso, idHex] = raw.split("::");
+      const postedAt = new Date(postedAtIso);
+      if (!postedAtIso || Number.isNaN(postedAt.getTime()) || !idHex) {
+        return null;
+      }
+
+      return {
+        postedAt,
+        id: new Types.ObjectId(idHex),
+        apiCursor: null
+      };
+    }
   } catch {
     return null;
   }

--- a/apps/worker/src/tiktok/tiktok-jobs.integration.test.ts
+++ b/apps/worker/src/tiktok/tiktok-jobs.integration.test.ts
@@ -2,11 +2,12 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { Types } from "mongoose";
 
-import { TIKTOK_VIDEO_UPDATE_CHANNEL } from "@trendpot/types";
+import type { Queue } from "bullmq";
+import { TIKTOK_VIDEO_UPDATE_CHANNEL, type TikTokMetricsRefreshJob } from "@trendpot/types";
 import { TikTokTokenCipher } from "@trendpot/utils";
 import type IORedis from "ioredis";
 
-import { createMetricsRefreshJobHandler } from "./tiktok-jobs";
+import { createInitialSyncJobHandler, createMetricsRefreshJobHandler } from "./tiktok-jobs";
 
 test("metrics refresh handler updates metrics and publishes redis notifications", async (t) => {
   const accountId = new Types.ObjectId();
@@ -140,4 +141,185 @@ test("metrics refresh handler updates metrics and publishes redis notifications"
   assert.equal(published[0].payload.event, "tiktok.videos.metrics_refreshed");
   assert.equal(published[0].payload.updated, 2);
   assert.equal(published[0].payload.total, 2);
+});
+
+test("initial sync handler fetches subsequent TikTok pages and upserts all videos", async (t) => {
+  const accountId = new Types.ObjectId();
+  const cipher = new TikTokTokenCipher();
+  const encryptedAccess = cipher.encrypt("access-token");
+  const encryptedRefresh = cipher.encrypt("refresh-token");
+
+  const accountRecord = {
+    _id: accountId,
+    userId: new Types.ObjectId(),
+    openId: "creator-open-id",
+    username: "creator",
+    scopes: ["video.list"],
+    accessToken: {
+      keyId: cipher.keyId,
+      ciphertext: encryptedAccess.ciphertext,
+      iv: encryptedAccess.iv,
+      authTag: encryptedAccess.authTag
+    },
+    refreshToken: {
+      keyId: cipher.keyId,
+      ciphertext: encryptedRefresh.ciphertext,
+      iv: encryptedRefresh.iv,
+      authTag: encryptedRefresh.authTag
+    },
+    accessTokenExpiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    refreshTokenExpiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000)
+  };
+
+  const videoOperations: Array<{ filter: unknown; update: unknown }> = [];
+  const accountUpdates: Array<{ filter: unknown; update: unknown }> = [];
+  const scheduledJobs: Array<{ name: string }> = [];
+
+  const dbStub = {
+    collection(name: string) {
+      if (name === "tiktok_accounts") {
+        return {
+          findOne: async (filter: unknown) => {
+            assert.deepEqual(filter, { _id: accountId });
+            return accountRecord;
+          },
+          updateOne: async (filter: unknown, update: unknown) => {
+            accountUpdates.push({ filter, update });
+            return { acknowledged: true };
+          }
+        };
+      }
+
+      if (name === "videos") {
+        return {
+          updateOne: async (filter: unknown, update: unknown) => {
+            videoOperations.push({ filter, update });
+            return { upsertedCount: 1 };
+          }
+        };
+      }
+
+      throw new Error(`Unexpected collection ${name}`);
+    }
+  };
+
+  const refreshQueue = {
+    async add(name: string) {
+      scheduledJobs.push({ name });
+    }
+  };
+
+  const published: Array<{ channel: string; payload: Record<string, unknown> }> = [];
+  const redisPublisher = {
+    publish: async (channel: string, message: string) => {
+      published.push({ channel, payload: JSON.parse(message) });
+      return 1;
+    }
+  };
+
+  const originalFetch = globalThis.fetch;
+  const fetchCalls: Array<{ cursor: string | null; max_count: number }> = [];
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const pages = [
+    {
+      videos: [
+        {
+          id: "video-1",
+          description: "first",
+          create_time: Math.floor(Date.now() / 1000),
+          share_url: "https://www.tiktok.com/@creator/video/video-1",
+          author: { username: "creator" },
+          stats: { play_count: 10 }
+        },
+        {
+          id: "video-2",
+          description: "second",
+          create_time: Math.floor(Date.now() / 1000) - 10,
+          share_url: "https://www.tiktok.com/@creator/video/video-2",
+          author: { username: "creator" },
+          stats: { play_count: 8 }
+        }
+      ],
+      cursor: "cursor-1",
+      has_more: true
+    },
+    {
+      videos: [
+        {
+          id: "video-3",
+          description: "third",
+          create_time: Math.floor(Date.now() / 1000) - 20,
+          share_url: "https://www.tiktok.com/@creator/video/video-3",
+          author: { username: "creator" },
+          stats: { play_count: 6 }
+        }
+      ],
+      cursor: "cursor-2",
+      has_more: true
+    },
+    {
+      videos: [
+        {
+          id: "video-4",
+          description: "fourth",
+          create_time: Math.floor(Date.now() / 1000) - 30,
+          share_url: "https://www.tiktok.com/@creator/video/video-4",
+          author: { username: "creator" },
+          stats: { play_count: 4 }
+        }
+      ],
+      cursor: null,
+      has_more: false
+    }
+  ];
+
+  globalThis.fetch = (async (_url: string | URL, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(String(init.body)) : { cursor: null, max_count: 0 };
+    fetchCalls.push({ cursor: body.cursor ?? null, max_count: body.max_count ?? 0 });
+    const page = pages.shift() ?? { videos: [], cursor: null, has_more: false };
+    return {
+      ok: true,
+      json: async () => ({
+        data: {
+          videos: page.videos,
+          cursor: page.cursor,
+          has_more: page.has_more
+        }
+      })
+    } as Response;
+  }) as typeof fetch;
+
+  const handler = createInitialSyncJobHandler({
+    refreshQueue: refreshQueue as unknown as Queue<TikTokMetricsRefreshJob>,
+    redisPublisher: redisPublisher as unknown as IORedis,
+    getMongoDb: async () => dbStub as never
+  });
+
+  const job = {
+    id: "job-1",
+    queueName: "tiktok:ingestion",
+    data: {
+      accountId: accountId.toHexString(),
+      userId: new Types.ObjectId().toHexString(),
+      requestId: "req-456",
+      trigger: "manual",
+      queuedAt: new Date().toISOString()
+    }
+  };
+
+  const result = await handler(job as never);
+
+  assert.equal(fetchCalls.length, 3);
+  assert.deepEqual(fetchCalls.map((call) => call.cursor), [null, "cursor-1", "cursor-2"]);
+  assert.equal(videoOperations.length, 4);
+  assert.equal(result.videos, 4);
+
+  assert.equal(accountUpdates.length >= 1, true);
+  assert.equal(published.length, 1);
+  assert.equal(published[0].payload.videoCount, 4);
+  assert.equal(scheduledJobs.length, 1);
 });

--- a/test-shims/@fastify/helmet/index.js
+++ b/test-shims/@fastify/helmet/index.js
@@ -1,0 +1,8 @@
+function helmet() {
+  return async function helmetPlugin() {
+    return undefined;
+  };
+}
+
+module.exports = helmet;
+module.exports.default = helmet;

--- a/test-shims/@nestjs/common/index.js
+++ b/test-shims/@nestjs/common/index.js
@@ -8,6 +8,7 @@ class NestException extends Error {
 class BadRequestException extends NestException {}
 class UnauthorizedException extends NestException {}
 class ForbiddenException extends NestException {}
+class ConflictException extends NestException {}
 class TooManyRequestsException extends NestException {}
 
 const decorator = () => () => undefined;
@@ -27,6 +28,7 @@ module.exports = {
   BadRequestException,
   UnauthorizedException,
   ForbiddenException,
+  ConflictException,
   TooManyRequestsException,
   Module,
   Injectable,

--- a/test-shims/@nestjs/graphql/index.js
+++ b/test-shims/@nestjs/graphql/index.js
@@ -9,6 +9,7 @@ const InputType = decorator;
 const Int = {};
 const Float = {};
 const GraphQLISODateTime = {};
+const registerEnumType = () => undefined;
 
 class GqlExecutionContext {
   constructor(payload) {
@@ -48,5 +49,6 @@ module.exports = {
   Int,
   Float,
   GraphQLISODateTime,
+  registerEnumType,
   GqlExecutionContext
 };

--- a/test-shims/ts-loader.mjs
+++ b/test-shims/ts-loader.mjs
@@ -13,6 +13,7 @@ const shimMap = new Map([
   ["@nestjs/mercurius", new URL("@nestjs/mercurius/index.js", shimBase).href],
   ["@nestjs/platform-fastify", new URL("@nestjs/platform-fastify/index.js", shimBase).href],
   ["@fastify/cors", new URL("@fastify/cors/index.js", shimBase).href],
+  ["@fastify/helmet", new URL("@fastify/helmet/index.js", shimBase).href],
   ["mongoose", new URL("mongoose/index.js", shimBase).href],
   ["@trendpot/types", new URL("@trendpot/types/index.js", shimBase).href],
   ["@trendpot/utils", new URL("@trendpot/utils/index.js", shimBase).href],


### PR DESCRIPTION
## Summary
- iterate the TikTok Display API when listing creator videos so cursors advance with `has_more`
- update the worker ingestion job to follow Display API pagination and accumulate all pages
- backfill unit and integration coverage plus test shims for the new pagination behavior

## Testing
- NODE_PATH=./test-shims node --loader ./test-shims/ts-loader.mjs --test apps/api/src/tiktok/tiktok.service.test.ts
- NODE_PATH=./test-shims node --loader ./test-shims/ts-loader.mjs --test apps/worker/src/tiktok/tiktok-jobs.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d93f71b374832e8c0334c3c48fc832