### PR TITLE
feat: add creator payouts module and dashboard

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { structuredErrorFormatter } from "./observability/error-formatter";
 import { PlatformAuthModule } from "./platform-auth/platform-auth.module";
 import { PlatformAuthService } from "./platform-auth/platform-auth.service";
 import { TikTokModule } from "./tiktok/tiktok.module";
+import { PayoutsModule } from "./payouts/payouts.module";
 
 @Module({
   imports: [
@@ -43,7 +44,8 @@ import { TikTokModule } from "./tiktok/tiktok.module";
       { name: SubmissionEntity.name, schema: SubmissionSchema }
     ]),
     PlatformAuthModule,
-    TikTokModule
+    TikTokModule,
+    PayoutsModule
   ],
   providers: [
     AppService,

--- a/apps/api/src/payouts/models/creator-donation.model.ts
+++ b/apps/api/src/payouts/models/creator-donation.model.ts
@@ -1,0 +1,89 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLISODateTime } from "@nestjs/graphql";
+import { DonationPayoutState } from "./donation-payout-state.enum";
+import { DonationStatus } from "./donation-status.enum";
+import { ConnectionPageInfoModel } from "./page-info.model";
+
+@ObjectType("CreatorDonation")
+export class CreatorDonationModel {
+  @Field()
+  declare id: string;
+
+  @Field(() => DonationStatus)
+  declare status: DonationStatus;
+
+  @Field(() => DonationPayoutState)
+  declare payoutState: DonationPayoutState;
+
+  @Field()
+  declare amountCents: number;
+
+  @Field()
+  declare netAmountCents: number;
+
+  @Field()
+  declare currency: string;
+
+  @Field(() => GraphQLISODateTime)
+  declare donatedAt: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare availableAt?: Date | null;
+
+  @Field({ nullable: true })
+  declare supporterName?: string | null;
+
+  @Field({ nullable: true })
+  declare challengeTitle?: string | null;
+
+  @Field({ nullable: true })
+  declare payoutBatchId?: string | null;
+}
+
+@ObjectType("CreatorDonationEdge")
+export class CreatorDonationEdgeModel {
+  @Field()
+  declare cursor: string;
+
+  @Field(() => CreatorDonationModel)
+  declare node: CreatorDonationModel;
+}
+
+@ObjectType("CreatorDonationTrendPoint")
+export class CreatorDonationTrendPointModel {
+  @Field(() => GraphQLISODateTime)
+  declare date: Date;
+
+  @Field()
+  declare amountCents: number;
+}
+
+@ObjectType("CreatorDonationStats")
+export class CreatorDonationStatsModel {
+  @Field()
+  declare lifetimeAmountCents: number;
+
+  @Field()
+  declare lifetimeDonationCount: number;
+
+  @Field()
+  declare pendingAmountCents: number;
+
+  @Field()
+  declare availableAmountCents: number;
+}
+
+@ObjectType("CreatorDonationConnection")
+export class CreatorDonationConnectionModel {
+  @Field(() => [CreatorDonationEdgeModel])
+  declare edges: CreatorDonationEdgeModel[];
+
+  @Field(() => ConnectionPageInfoModel)
+  declare pageInfo: ConnectionPageInfoModel;
+
+  @Field(() => CreatorDonationStatsModel)
+  declare stats: CreatorDonationStatsModel;
+
+  @Field(() => [CreatorDonationTrendPointModel])
+  declare trend: CreatorDonationTrendPointModel[];
+}

--- a/apps/api/src/payouts/models/donation-payout-state.enum.ts
+++ b/apps/api/src/payouts/models/donation-payout-state.enum.ts
@@ -1,0 +1,14 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum DonationPayoutState {
+  Unassigned = "unassigned",
+  Scheduled = "scheduled",
+  Processing = "processing",
+  Paid = "paid",
+  Failed = "failed"
+}
+
+registerEnumType(DonationPayoutState, {
+  name: "DonationPayoutState",
+  description: "Payout lifecycle state for a donation once it has cleared."
+});

--- a/apps/api/src/payouts/models/donation-status.enum.ts
+++ b/apps/api/src/payouts/models/donation-status.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum DonationStatus {
+  Pending = "pending",
+  Succeeded = "succeeded",
+  Refunded = "refunded",
+  Failed = "failed"
+}
+
+registerEnumType(DonationStatus, {
+  name: "DonationStatus",
+  description: "Lifecycle status of a donor contribution."
+});

--- a/apps/api/src/payouts/models/page-info.model.ts
+++ b/apps/api/src/payouts/models/page-info.model.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+
+@ObjectType("ConnectionPageInfo")
+export class ConnectionPageInfoModel {
+  @Field({ nullable: true })
+  declare endCursor: string | null;
+
+  @Field()
+  declare hasNextPage: boolean;
+}

--- a/apps/api/src/payouts/models/payout-batch-status.enum.ts
+++ b/apps/api/src/payouts/models/payout-batch-status.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum PayoutBatchStatus {
+  Scheduled = "scheduled",
+  Processing = "processing",
+  Paid = "paid",
+  Failed = "failed"
+}
+
+registerEnumType(PayoutBatchStatus, {
+  name: "PayoutBatchStatus",
+  description: "Processing status for a scheduled creator payout batch."
+});

--- a/apps/api/src/payouts/models/payout-batch.model.ts
+++ b/apps/api/src/payouts/models/payout-batch.model.ts
@@ -1,0 +1,61 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLISODateTime } from "@nestjs/graphql";
+import { PayoutBatchStatus } from "./payout-batch-status.enum";
+import { ConnectionPageInfoModel } from "./page-info.model";
+
+@ObjectType("PayoutBatch")
+export class PayoutBatchModel {
+  @Field()
+  declare id: string;
+
+  @Field(() => PayoutBatchStatus)
+  declare status: PayoutBatchStatus;
+
+  @Field(() => GraphQLISODateTime)
+  declare scheduledFor: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare completedAt?: Date | null;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare startedAt?: Date | null;
+
+  @Field()
+  declare donationCount: number;
+
+  @Field()
+  declare totalAmountCents: number;
+
+  @Field()
+  declare netAmountCents: number;
+
+  @Field()
+  declare currency: string;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare periodStart?: Date | null;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare periodEnd?: Date | null;
+
+  @Field({ nullable: true })
+  declare failureReason?: string | null;
+}
+
+@ObjectType("PayoutBatchEdge")
+export class PayoutBatchEdgeModel {
+  @Field()
+  declare cursor: string;
+
+  @Field(() => PayoutBatchModel)
+  declare node: PayoutBatchModel;
+}
+
+@ObjectType("PayoutBatchConnection")
+export class PayoutBatchConnectionModel {
+  @Field(() => [PayoutBatchEdgeModel])
+  declare edges: PayoutBatchEdgeModel[];
+
+  @Field(() => ConnectionPageInfoModel)
+  declare pageInfo: ConnectionPageInfoModel;
+}

--- a/apps/api/src/payouts/models/payout-notification-type.enum.ts
+++ b/apps/api/src/payouts/models/payout-notification-type.enum.ts
@@ -1,0 +1,14 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum PayoutNotificationType {
+  DonationCleared = "donation.cleared",
+  PayoutScheduled = "payout.scheduled",
+  PayoutProcessing = "payout.processing",
+  PayoutPaid = "payout.paid",
+  PayoutFailed = "payout.failed"
+}
+
+registerEnumType(PayoutNotificationType, {
+  name: "PayoutNotificationType",
+  description: "Event types surfaced in the creator payout notification center."
+});

--- a/apps/api/src/payouts/models/payout-notification.model.ts
+++ b/apps/api/src/payouts/models/payout-notification.model.ts
@@ -1,0 +1,61 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { GraphQLISODateTime } from "@nestjs/graphql";
+import { ConnectionPageInfoModel } from "./page-info.model";
+import { PayoutNotificationType } from "./payout-notification-type.enum";
+
+@ObjectType("PayoutNotificationMetadata")
+export class PayoutNotificationMetadataModel {
+  @Field({ nullable: true })
+  declare donationId?: string | null;
+
+  @Field({ nullable: true })
+  declare payoutBatchId?: string | null;
+
+  @Field({ nullable: true })
+  declare amountCents?: number | null;
+
+  @Field({ nullable: true })
+  declare currency?: string | null;
+}
+
+@ObjectType("PayoutNotification")
+export class PayoutNotificationModel {
+  @Field()
+  declare id: string;
+
+  @Field(() => PayoutNotificationType)
+  declare type: PayoutNotificationType;
+
+  @Field()
+  declare message: string;
+
+  @Field(() => GraphQLISODateTime)
+  declare createdAt: Date;
+
+  @Field(() => GraphQLISODateTime)
+  declare eventAt: Date;
+
+  @Field(() => GraphQLISODateTime, { nullable: true })
+  declare readAt?: Date | null;
+
+  @Field(() => PayoutNotificationMetadataModel, { nullable: true })
+  declare metadata?: PayoutNotificationMetadataModel | null;
+}
+
+@ObjectType("PayoutNotificationEdge")
+export class PayoutNotificationEdgeModel {
+  @Field()
+  declare cursor: string;
+
+  @Field(() => PayoutNotificationModel)
+  declare node: PayoutNotificationModel;
+}
+
+@ObjectType("PayoutNotificationConnection")
+export class PayoutNotificationConnectionModel {
+  @Field(() => [PayoutNotificationEdgeModel])
+  declare edges: PayoutNotificationEdgeModel[];
+
+  @Field(() => ConnectionPageInfoModel)
+  declare pageInfo: ConnectionPageInfoModel;
+}

--- a/apps/api/src/payouts/payouts.module.ts
+++ b/apps/api/src/payouts/payouts.module.ts
@@ -1,0 +1,23 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { PayoutsResolver } from "./payouts.resolver";
+import { PayoutsService } from "./payouts.service";
+import { DonationEntity, DonationSchema } from "./schemas/donation.schema";
+import { PayoutBatchEntity, PayoutBatchSchema } from "./schemas/payout-batch.schema";
+import {
+  PayoutNotificationEntity,
+  PayoutNotificationSchema
+} from "./schemas/payout-notification.schema";
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: DonationEntity.name, schema: DonationSchema },
+      { name: PayoutBatchEntity.name, schema: PayoutBatchSchema },
+      { name: PayoutNotificationEntity.name, schema: PayoutNotificationSchema }
+    ])
+  ],
+  providers: [PayoutsResolver, PayoutsService],
+  exports: [PayoutsService]
+})
+export class PayoutsModule {}

--- a/apps/api/src/payouts/payouts.resolver.ts
+++ b/apps/api/src/payouts/payouts.resolver.ts
@@ -1,0 +1,73 @@
+import { Args, Context, Int, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { ForbiddenException, UnauthorizedException } from "@nestjs/common";
+import { Roles } from "../auth/auth.decorators";
+import type { GraphQLContext } from "../observability/graphql-context";
+import { PayoutsService } from "./payouts.service";
+import { CreatorDonationConnectionModel } from "./models/creator-donation.model";
+import { PayoutBatchConnectionModel } from "./models/payout-batch.model";
+import { PayoutNotificationConnectionModel } from "./models/payout-notification.model";
+
+@Resolver()
+export class PayoutsResolver {
+  constructor(private readonly payoutsService: PayoutsService) {}
+
+  @Roles("creator", "operator", "admin")
+  @Query(() => CreatorDonationConnectionModel, { name: "creatorDonations" })
+  async creatorDonations(
+    @Context() context: GraphQLContext,
+    @Args("first", { type: () => Int, nullable: true }) first?: number,
+    @Args("after", { type: () => String, nullable: true }) after?: string
+  ) {
+    const user = this.requireUser(context);
+    return this.payoutsService.listCreatorDonations(user.id, { first, after });
+  }
+
+  @Roles("creator", "operator", "admin")
+  @Query(() => PayoutBatchConnectionModel, { name: "payoutBatches" })
+  async payoutBatches(
+    @Context() context: GraphQLContext,
+    @Args("first", { type: () => Int, nullable: true }) first?: number,
+    @Args("after", { type: () => String, nullable: true }) after?: string
+  ) {
+    const user = this.requireUser(context);
+    return this.payoutsService.listPayoutBatches(user.id, { first, after });
+  }
+
+  @Roles("creator", "operator", "admin")
+  @Query(() => PayoutNotificationConnectionModel, { name: "payoutNotificationFeed" })
+  async payoutNotificationFeed(
+    @Context() context: GraphQLContext,
+    @Args("first", { type: () => Int, nullable: true }) first?: number,
+    @Args("after", { type: () => String, nullable: true }) after?: string
+  ) {
+    const user = this.requireUser(context);
+    return this.payoutsService.listNotifications(user.id, { first, after });
+  }
+
+  @Roles("creator", "operator", "admin")
+  @Mutation(() => Int, { name: "markPayoutNotificationsRead" })
+  async markPayoutNotificationsRead(
+    @Context() context: GraphQLContext,
+    @Args("ids", { type: () => [String] }) ids: string[]
+  ) {
+    const user = this.requireUser(context);
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return 0;
+    }
+
+    return this.payoutsService.markNotificationsRead(user.id, ids);
+  }
+
+  private requireUser(context: GraphQLContext) {
+    const user = context.user;
+    if (!user) {
+      throw new UnauthorizedException("Authentication is required to access creator payouts.");
+    }
+
+    if (!user.roles.includes("creator") && !user.roles.includes("admin") && !user.roles.includes("operator")) {
+      throw new ForbiddenException("You do not have permission to view payout data.");
+    }
+
+    return user;
+  }
+}

--- a/apps/api/src/payouts/payouts.service.ts
+++ b/apps/api/src/payouts/payouts.service.ts
@@ -1,0 +1,349 @@
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Types, type Model } from "mongoose";
+import { DonationEntity, type DonationDocument } from "./schemas/donation.schema";
+import { PayoutBatchEntity, type PayoutBatchDocument } from "./schemas/payout-batch.schema";
+import {
+  PayoutNotificationEntity,
+  type PayoutNotificationDocument
+} from "./schemas/payout-notification.schema";
+import { DonationStatus } from "./models/donation-status.enum";
+import { DonationPayoutState } from "./models/donation-payout-state.enum";
+import { CreatorDonationConnectionModel, CreatorDonationTrendPointModel } from "./models/creator-donation.model";
+import { PayoutBatchConnectionModel } from "./models/payout-batch.model";
+import { PayoutNotificationConnectionModel } from "./models/payout-notification.model";
+
+interface ConnectionParams {
+  first?: number;
+  after?: string;
+}
+
+@Injectable()
+export class PayoutsService {
+  constructor(
+    @InjectModel(DonationEntity.name)
+    private readonly donationModel: Model<DonationDocument>,
+    @InjectModel(PayoutBatchEntity.name)
+    private readonly payoutBatchModel: Model<PayoutBatchDocument>,
+    @InjectModel(PayoutNotificationEntity.name)
+    private readonly notificationModel: Model<PayoutNotificationDocument>
+  ) {}
+
+  async listCreatorDonations(userId: string, params: ConnectionParams = {}): Promise<CreatorDonationConnectionModel> {
+    const creatorId = this.toObjectId(userId);
+    const limit = this.sanitizeLimit(params.first ?? 20);
+    const cursor = this.parseCursor(params.after);
+
+    const filters: Record<string, unknown>[] = [{ creatorUserId: creatorId }];
+    if (cursor) {
+      filters.push({ _id: { $lt: cursor } });
+    }
+
+    const documents = await this.donationModel
+      .find(filters.length ? { $and: filters } : {})
+      .sort({ _id: -1 })
+      .limit(limit + 1)
+      .lean();
+
+    const hasNextPage = documents.length > limit;
+    const window = hasNextPage ? documents.slice(0, -1) : documents;
+
+    const edges = window.map((doc) => ({
+      cursor: doc._id.toString(),
+      node: {
+        id: doc._id.toString(),
+        status: doc.status,
+        payoutState: doc.payoutState,
+        amountCents: doc.amountCents,
+        netAmountCents: Math.max(doc.amountCents - (doc.platformFeeCents ?? 0), 0),
+        currency: doc.currency,
+        donatedAt: doc.donatedAt,
+        availableAt: doc.availableAt ?? null,
+        supporterName: doc.supporterName ?? null,
+        challengeTitle: doc.challengeTitle ?? null,
+        payoutBatchId: doc.payoutBatchId ? String(doc.payoutBatchId) : null
+      }
+    }));
+
+    const endCursor = edges.length > 0 ? edges[edges.length - 1]?.cursor ?? null : null;
+
+    const [lifetimeSummary] = await this.donationModel.aggregate([
+      {
+        $match: {
+          creatorUserId: creatorId,
+          status: DonationStatus.Succeeded
+        }
+      },
+      {
+        $group: {
+          _id: null,
+          amount: { $sum: "$amountCents" },
+          count: { $sum: 1 }
+        }
+      }
+    ]);
+
+    const [pendingSummary] = await this.donationModel.aggregate([
+      {
+        $match: {
+          creatorUserId: creatorId,
+          status: DonationStatus.Pending
+        }
+      },
+      {
+        $group: {
+          _id: null,
+          amount: { $sum: "$amountCents" }
+        }
+      }
+    ]);
+
+    const [availableSummary] = await this.donationModel.aggregate([
+      {
+        $match: {
+          creatorUserId: creatorId,
+          status: DonationStatus.Succeeded,
+          payoutState: { $in: [DonationPayoutState.Unassigned, DonationPayoutState.Scheduled, DonationPayoutState.Processing] }
+        }
+      },
+      {
+        $group: {
+          _id: null,
+          amount: { $sum: "$amountCents" }
+        }
+      }
+    ]);
+
+    const trend = await this.buildDonationTrend(creatorId);
+
+    return {
+      edges,
+      pageInfo: {
+        endCursor,
+        hasNextPage
+      },
+      stats: {
+        lifetimeAmountCents: lifetimeSummary?.amount ?? 0,
+        lifetimeDonationCount: lifetimeSummary?.count ?? 0,
+        pendingAmountCents: pendingSummary?.amount ?? 0,
+        availableAmountCents: availableSummary?.amount ?? 0
+      },
+      trend
+    };
+  }
+
+  async listPayoutBatches(userId: string, params: ConnectionParams = {}): Promise<PayoutBatchConnectionModel> {
+    const creatorId = this.toObjectId(userId);
+    const limit = this.sanitizeLimit(params.first ?? 10);
+    const cursor = this.parseCursor(params.after);
+
+    const filters: Record<string, unknown>[] = [{ creatorUserId: creatorId }];
+    if (cursor) {
+      filters.push({ _id: { $lt: cursor } });
+    }
+
+    const documents = await this.payoutBatchModel
+      .find(filters.length ? { $and: filters } : {})
+      .sort({ scheduledFor: -1, _id: -1 })
+      .limit(limit + 1)
+      .lean();
+
+    const hasNextPage = documents.length > limit;
+    const window = hasNextPage ? documents.slice(0, -1) : documents;
+
+    const edges = window.map((doc) => ({
+      cursor: doc._id.toString(),
+      node: {
+        id: doc._id.toString(),
+        status: doc.status,
+        scheduledFor: doc.scheduledFor,
+        completedAt: doc.completedAt ?? null,
+        startedAt: doc.startedAt ?? null,
+        donationCount: doc.donationCount,
+        totalAmountCents: doc.totalAmountCents,
+        netAmountCents: doc.netAmountCents,
+        currency: doc.currency,
+        periodStart: doc.periodStart ?? null,
+        periodEnd: doc.periodEnd ?? null,
+        failureReason: doc.failureReason ?? null
+      }
+    }));
+
+    const endCursor = edges.length > 0 ? edges[edges.length - 1]?.cursor ?? null : null;
+
+    return {
+      edges,
+      pageInfo: {
+        endCursor,
+        hasNextPage
+      }
+    };
+  }
+
+  async listNotifications(
+    userId: string,
+    params: ConnectionParams = {}
+  ): Promise<PayoutNotificationConnectionModel> {
+    const ownerId = this.toObjectId(userId);
+    const limit = this.sanitizeLimit(params.first ?? 15);
+    const cursor = this.parseCursor(params.after);
+
+    const filters: Record<string, unknown>[] = [{ userId: ownerId }];
+    if (cursor) {
+      filters.push({ _id: { $lt: cursor } });
+    }
+
+    const documents = await this.notificationModel
+      .find(filters.length ? { $and: filters } : {})
+      .sort({ eventAt: -1, _id: -1 })
+      .limit(limit + 1)
+      .lean();
+
+    const hasNextPage = documents.length > limit;
+    const window = hasNextPage ? documents.slice(0, -1) : documents;
+
+    const edges = window.map((doc) => ({
+      cursor: doc._id.toString(),
+      node: {
+        id: doc._id.toString(),
+        type: doc.type,
+        message: doc.message,
+        createdAt: doc.createdAt,
+        eventAt: doc.eventAt,
+        readAt: doc.readAt ?? null,
+        metadata: this.normalizeNotificationMetadata(doc.metadata)
+      }
+    }));
+
+    const endCursor = edges.length > 0 ? edges[edges.length - 1]?.cursor ?? null : null;
+
+    return {
+      edges,
+      pageInfo: {
+        endCursor,
+        hasNextPage
+      }
+    };
+  }
+
+  async markNotificationsRead(userId: string, ids: string[]): Promise<number> {
+    if (ids.length === 0) {
+      return 0;
+    }
+
+    const ownerId = this.toObjectId(userId);
+    const objectIds = ids
+      .map((id) => this.parseCursor(id))
+      .filter((value): value is Types.ObjectId => Boolean(value));
+
+    if (objectIds.length === 0) {
+      return 0;
+    }
+
+    const result = await this.notificationModel.updateMany(
+      { _id: { $in: objectIds }, userId: ownerId, readAt: null },
+      { $set: { readAt: new Date() } }
+    );
+
+    return result.modifiedCount ?? 0;
+  }
+
+  private sanitizeLimit(limit: number): number {
+    if (!Number.isFinite(limit) || limit <= 0) {
+      return 20;
+    }
+
+    return Math.min(Math.floor(limit), 50);
+  }
+
+  private parseCursor(cursor?: string): Types.ObjectId | null {
+    if (!cursor || cursor.trim().length === 0) {
+      return null;
+    }
+
+    if (!Types.ObjectId.isValid(cursor)) {
+      return null;
+    }
+
+    return new Types.ObjectId(cursor);
+  }
+
+  private toObjectId(id: string): Types.ObjectId {
+    if (!Types.ObjectId.isValid(id)) {
+      throw new Error("A valid identifier is required to access creator payouts.");
+    }
+
+    return new Types.ObjectId(id);
+  }
+
+  private normalizeNotificationMetadata(metadata: Record<string, unknown> | undefined) {
+    if (!metadata || typeof metadata !== "object") {
+      return null;
+    }
+
+    const normalized: Record<string, unknown> = {};
+
+    if (typeof metadata.donationId === "string") {
+      normalized.donationId = metadata.donationId;
+    }
+
+    if (typeof metadata.payoutBatchId === "string") {
+      normalized.payoutBatchId = metadata.payoutBatchId;
+    }
+
+    if (typeof metadata.amountCents === "number") {
+      normalized.amountCents = metadata.amountCents;
+    }
+
+    if (typeof metadata.currency === "string") {
+      normalized.currency = metadata.currency;
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : null;
+  }
+
+  private async buildDonationTrend(creatorId: Types.ObjectId): Promise<CreatorDonationTrendPointModel[]> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const windowDays = 14;
+    const start = new Date(today);
+    start.setDate(start.getDate() - (windowDays - 1));
+
+    const raw = await this.donationModel.aggregate<{
+      _id: string;
+      amount: number;
+    }>([
+      {
+        $match: {
+          creatorUserId: creatorId,
+          status: DonationStatus.Succeeded,
+          donatedAt: { $gte: start }
+        }
+      },
+      {
+        $group: {
+          _id: {
+            $dateToString: { format: "%Y-%m-%d", date: "$donatedAt" }
+          },
+          amount: { $sum: "$amountCents" }
+        }
+      },
+      { $sort: { _id: 1 } }
+    ]);
+
+    const trendMap = new Map(raw.map((entry) => [entry._id, entry.amount]));
+    const points: CreatorDonationTrendPointModel[] = [];
+
+    for (let i = 0; i < windowDays; i += 1) {
+      const date = new Date(start);
+      date.setDate(start.getDate() + i);
+      const key = date.toISOString().slice(0, 10);
+      points.push({
+        date,
+        amountCents: trendMap.get(key) ?? 0
+      });
+    }
+
+    return points;
+  }
+}

--- a/apps/api/src/payouts/schemas/donation.schema.ts
+++ b/apps/api/src/payouts/schemas/donation.schema.ts
@@ -1,0 +1,69 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, SchemaTypes } from "mongoose";
+import { SubmissionEntity } from "../../models/submission.schema";
+import { UserEntity } from "../../platform-auth/schemas/user.schema";
+import { DonationPayoutState } from "../models/donation-payout-state.enum";
+import { DonationStatus } from "../models/donation-status.enum";
+import { PayoutBatchEntity } from "./payout-batch.schema";
+
+@Schema({
+  collection: "donations",
+  timestamps: true,
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+})
+export class DonationEntity {
+  @Prop({ type: SchemaTypes.ObjectId, ref: UserEntity.name, required: true, index: true })
+  declare creatorUserId: string;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: UserEntity.name, required: true })
+  declare donorUserId: string;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: SubmissionEntity.name, required: true })
+  declare submissionId: string;
+
+  @Prop({ type: String, required: true })
+  declare challengeId: string;
+
+  @Prop({ type: String, required: false })
+  declare challengeTitle?: string;
+
+  @Prop({ type: Number, required: true, min: 0 })
+  declare amountCents: number;
+
+  @Prop({ type: Number, required: true, min: 0, default: 0 })
+  declare platformFeeCents: number;
+
+  @Prop({ type: String, required: true, minlength: 3, maxlength: 3, uppercase: true })
+  declare currency: string;
+
+  @Prop({ type: String, required: true, enum: DonationStatus, default: DonationStatus.Pending })
+  declare status: DonationStatus;
+
+  @Prop({ type: String, required: true, enum: DonationPayoutState, default: DonationPayoutState.Unassigned })
+  declare payoutState: DonationPayoutState;
+
+  @Prop({ type: SchemaTypes.Date, required: true })
+  declare donatedAt: Date;
+
+  @Prop({ type: SchemaTypes.Date, required: false })
+  declare availableAt?: Date;
+
+  @Prop({ type: SchemaTypes.ObjectId, ref: PayoutBatchEntity.name, default: null })
+  declare payoutBatchId?: string | null;
+
+  @Prop({ type: String, required: false })
+  declare supporterName?: string;
+}
+
+export type DonationDocument = HydratedDocument<DonationEntity>;
+
+export const DonationSchema = SchemaFactory.createForClass(DonationEntity);
+
+DonationSchema.virtual("id").get(function (this: DonationEntity & { _id: unknown }) {
+  return String((this as { _id: { toString(): string } })._id);
+});
+
+DonationSchema.index({ creatorUserId: 1, donatedAt: -1, _id: -1 });
+DonationSchema.index({ creatorUserId: 1, status: 1, donatedAt: -1 });
+DonationSchema.index({ creatorUserId: 1, payoutState: 1, donatedAt: -1 });

--- a/apps/api/src/payouts/schemas/payout-batch.schema.ts
+++ b/apps/api/src/payouts/schemas/payout-batch.schema.ts
@@ -1,0 +1,59 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, SchemaTypes } from "mongoose";
+import { UserEntity } from "../../platform-auth/schemas/user.schema";
+import { PayoutBatchStatus } from "../models/payout-batch-status.enum";
+
+@Schema({
+  collection: "payout_batches",
+  timestamps: true,
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+})
+export class PayoutBatchEntity {
+  @Prop({ type: SchemaTypes.ObjectId, ref: UserEntity.name, required: true, index: true })
+  declare creatorUserId: string;
+
+  @Prop({ type: SchemaTypes.Date, required: true })
+  declare scheduledFor: Date;
+
+  @Prop({ type: SchemaTypes.Date, required: false })
+  declare startedAt?: Date;
+
+  @Prop({ type: SchemaTypes.Date, required: false })
+  declare completedAt?: Date;
+
+  @Prop({ type: SchemaTypes.Date, required: false })
+  declare periodStart?: Date;
+
+  @Prop({ type: SchemaTypes.Date, required: false })
+  declare periodEnd?: Date;
+
+  @Prop({ type: Number, required: true, min: 0 })
+  declare totalAmountCents: number;
+
+  @Prop({ type: Number, required: true, min: 0 })
+  declare netAmountCents: number;
+
+  @Prop({ type: Number, required: true, min: 0 })
+  declare donationCount: number;
+
+  @Prop({ type: String, required: true, minlength: 3, maxlength: 3, uppercase: true })
+  declare currency: string;
+
+  @Prop({ type: String, required: true, enum: PayoutBatchStatus, default: PayoutBatchStatus.Scheduled })
+  declare status: PayoutBatchStatus;
+
+  @Prop({ type: String, required: false })
+  declare failureReason?: string;
+}
+
+export type PayoutBatchDocument = HydratedDocument<PayoutBatchEntity>;
+
+export const PayoutBatchSchema = SchemaFactory.createForClass(PayoutBatchEntity);
+
+PayoutBatchSchema.virtual("id").get(function (this: PayoutBatchEntity & { _id: unknown }) {
+  return String((this as { _id: { toString(): string } })._id);
+});
+
+PayoutBatchSchema.index({ creatorUserId: 1, scheduledFor: -1, _id: -1 });
+PayoutBatchSchema.index({ creatorUserId: 1, status: 1, scheduledFor: -1 });

--- a/apps/api/src/payouts/schemas/payout-notification.schema.ts
+++ b/apps/api/src/payouts/schemas/payout-notification.schema.ts
@@ -1,0 +1,41 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, SchemaTypes } from "mongoose";
+import { UserEntity } from "../../platform-auth/schemas/user.schema";
+import { PayoutNotificationType } from "../models/payout-notification-type.enum";
+
+@Schema({
+  collection: "payout_notifications",
+  timestamps: true,
+  toJSON: { virtuals: true },
+  toObject: { virtuals: true }
+})
+export class PayoutNotificationEntity {
+  @Prop({ type: SchemaTypes.ObjectId, ref: UserEntity.name, required: true, index: true })
+  declare userId: string;
+
+  @Prop({ type: String, required: true, enum: PayoutNotificationType })
+  declare type: PayoutNotificationType;
+
+  @Prop({ type: String, required: true })
+  declare message: string;
+
+  @Prop({ type: SchemaTypes.Date, required: true })
+  declare eventAt: Date;
+
+  @Prop({ type: SchemaTypes.Date, required: false, default: null })
+  declare readAt?: Date | null;
+
+  @Prop({ type: SchemaTypes.Mixed, required: false })
+  declare metadata?: Record<string, unknown>;
+}
+
+export type PayoutNotificationDocument = HydratedDocument<PayoutNotificationEntity>;
+
+export const PayoutNotificationSchema = SchemaFactory.createForClass(PayoutNotificationEntity);
+
+PayoutNotificationSchema.virtual("id").get(function (this: PayoutNotificationEntity & { _id: unknown }) {
+  return String((this as { _id: { toString(): string } })._id);
+});
+
+PayoutNotificationSchema.index({ userId: 1, eventAt: -1, _id: -1 });
+PayoutNotificationSchema.index({ userId: 1, readAt: 1, eventAt: -1 });

--- a/apps/web/src/app/me/payouts/page.tsx
+++ b/apps/web/src/app/me/payouts/page.tsx
@@ -1,0 +1,85 @@
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { CreatorPayoutDashboard } from "@/components/payouts/creator-payout-dashboard";
+import { viewerQueryOptions } from "@/lib/auth-queries";
+import {
+  creatorDonationsQueryOptions,
+  fetchCreatorDonations,
+  payoutBatchesQueryOptions,
+  fetchPayoutBatches,
+  payoutNotificationsQueryOptions,
+  fetchPayoutNotifications
+} from "@/lib/payouts-queries";
+import { loadViewerOnServer } from "@/lib/server-auth";
+
+export const metadata: Metadata = {
+  title: "Payouts · TrendPot",
+  description: "Monitor donation performance and upcoming creator payouts."
+};
+
+const buildServerHeaders = () => {
+  const jar = cookies();
+  const cookieHeader = jar
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join("; ");
+
+  return {
+    Cookie: cookieHeader,
+    "x-requested-with": "nextjs"
+  } as const;
+};
+
+export default async function CreatorPayoutsPage() {
+  const viewer = await loadViewerOnServer();
+
+  if (!viewer.user) {
+    redirect("/login");
+  }
+
+  const roles = viewer.user.roles ?? [];
+  const isCreator = roles.includes("creator") || roles.includes("admin") || roles.includes("operator");
+
+  if (!isCreator) {
+    redirect("/account?error=forbidden");
+  }
+
+  const headers = buildServerHeaders();
+  const [donations, batches, notifications] = await Promise.all([
+    fetchCreatorDonations({ first: 20 }, { init: { headers } }),
+    fetchPayoutBatches({ first: 6 }, { init: { headers } }),
+    fetchPayoutNotifications({ first: 10 }, { init: { headers } })
+  ]);
+
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(viewerQueryOptions().queryKey, viewer);
+
+  const donationOptions = creatorDonationsQueryOptions({ first: 20 });
+  const batchOptions = payoutBatchesQueryOptions({ first: 6 });
+  const notificationOptions = payoutNotificationsQueryOptions({ first: 10 });
+
+  queryClient.setQueryData(donationOptions.queryKey, donations);
+  queryClient.setQueryData(batchOptions.queryKey, batches);
+  queryClient.setQueryData(notificationOptions.queryKey, notifications);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <section className="flex flex-col gap-6 py-8">
+        <header className="space-y-2">
+          <p className="text-sm uppercase tracking-widest text-emerald-300">Creator hub</p>
+          <h1 className="text-3xl font-semibold text-slate-100">Payouts</h1>
+          <p className="max-w-2xl text-sm text-slate-400">
+            Review donation performance, monitor scheduled disbursements, and keep tabs on payout notifications in one place.
+          </p>
+        </header>
+        <CreatorPayoutDashboard
+          initialDonations={donations}
+          initialBatches={batches}
+          initialNotifications={notifications}
+        />
+      </section>
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/components/payouts/creator-donations-table.tsx
+++ b/apps/web/src/components/payouts/creator-donations-table.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Button, Card, CardContent, CardHeader } from "@trendpot/ui";
+import type { CreatorDonationConnection } from "@trendpot/types";
+import { formatCurrencyFromCents } from "@/lib/money";
+
+interface CreatorDonationsTableProps {
+  connection: CreatorDonationConnection | undefined;
+  isLoading: boolean;
+  onLoadMore?: () => void;
+  isFetchingMore?: boolean;
+}
+
+const describePayoutState = (state: string) => {
+  switch (state) {
+    case "unassigned":
+      return "Queued";
+    case "scheduled":
+      return "Scheduled";
+    case "processing":
+      return "Processing";
+    case "paid":
+      return "Paid out";
+    case "failed":
+      return "Failed";
+    default:
+      return state;
+  }
+};
+
+export function CreatorDonationsTable({
+  connection,
+  isLoading,
+  onLoadMore,
+  isFetchingMore,
+}: CreatorDonationsTableProps) {
+  const donations = connection?.edges ?? [];
+  const currency = donations[0]?.node.currency ?? "KES";
+  const canLoadMore = Boolean(connection?.pageInfo.hasNextPage && onLoadMore);
+
+  return (
+    <Card className="overflow-hidden" aria-busy={isLoading}>
+      <CardHeader className="gap-2">
+        <h2 className="text-lg font-semibold text-slate-100">Recent donations</h2>
+        <p className="text-sm text-slate-400">Detailed ledger of supporter contributions.</p>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-800 text-left" aria-live="polite">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3">Supporter</th>
+              <th scope="col" className="px-4 py-3">Amount</th>
+              <th scope="col" className="px-4 py-3">Net</th>
+              <th scope="col" className="px-4 py-3">Status</th>
+              <th scope="col" className="px-4 py-3">Payout</th>
+              <th scope="col" className="px-4 py-3">Date</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-900/60 text-sm text-slate-200">
+            {donations.map(({ node }) => {
+              const amount = formatCurrencyFromCents(node.amountCents, node.currency ?? currency);
+              const netAmount = formatCurrencyFromCents(node.netAmountCents, node.currency ?? currency);
+              const donatedAt = new Date(node.donatedAt).toLocaleString();
+              const payoutState = describePayoutState(node.payoutState);
+
+              return (
+                <tr key={node.id} className="bg-slate-950/40">
+                  <td className="px-4 py-3">
+                    <div className="flex flex-col">
+                      <span className="font-medium text-slate-100">{node.supporterName ?? "Anonymous"}</span>
+                      {node.challengeTitle ? (
+                        <span className="text-xs text-slate-500">Challenge · {node.challengeTitle}</span>
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">{amount}</td>
+                  <td className="px-4 py-3">{netAmount}</td>
+                  <td className="px-4 py-3">
+                    <span className="rounded-full bg-slate-800 px-3 py-1 text-xs font-medium text-slate-200 uppercase">
+                      {node.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">{payoutState}</td>
+                  <td className="px-4 py-3 text-slate-400">{donatedAt}</td>
+                </tr>
+              );
+            })}
+            {donations.length === 0 && !isLoading ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                  No donations have been recorded yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+        {canLoadMore ? (
+          <div className="mt-6 flex justify-center">
+            <Button onClick={onLoadMore} disabled={isFetchingMore} aria-live="polite">
+              {isFetchingMore ? "Loading…" : "Load more"}
+            </Button>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/payouts/creator-earnings-summary.tsx
+++ b/apps/web/src/components/payouts/creator-earnings-summary.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@trendpot/ui";
+import type { CreatorDonationConnection } from "@trendpot/types";
+import { formatCurrencyFromCents } from "@/lib/money";
+
+interface CreatorEarningsSummaryProps {
+  connection: CreatorDonationConnection | undefined;
+  isLoading: boolean;
+  error?: string | null;
+}
+
+const formatDateLabel = (isoDate: string) => {
+  try {
+    return new Date(isoDate).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric"
+    });
+  } catch (error) {
+    return isoDate;
+  }
+};
+
+export function CreatorEarningsSummary({ connection, isLoading, error }: CreatorEarningsSummaryProps) {
+  const currency = connection?.edges[0]?.node.currency ?? "KES";
+  const stats = connection?.stats;
+  const trend = connection?.trend ?? [];
+
+  return (
+    <Card className="flex flex-col overflow-hidden" aria-busy={isLoading} aria-live="polite">
+      <CardHeader className="gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-slate-100">Earnings overview</h2>
+          <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+            Last {trend.length || 0} days
+          </span>
+        </div>
+        <p className="text-sm text-slate-400">
+          Track how donations are converting into upcoming payouts. Values are shown in {currency}.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        {error ? (
+          <p role="alert" className="rounded-xl bg-rose-900/30 px-4 py-3 text-sm text-rose-200">
+            {error}
+          </p>
+        ) : null}
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/30 px-4 py-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Lifetime earnings</dt>
+            <dd className="mt-2 text-2xl font-semibold text-slate-100">
+              {stats ? formatCurrencyFromCents(stats.lifetimeAmountCents, currency) : "—"}
+            </dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/30 px-4 py-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Pending capture</dt>
+            <dd className="mt-2 text-2xl font-semibold text-slate-100">
+              {stats ? formatCurrencyFromCents(stats.pendingAmountCents, currency) : "—"}
+            </dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/30 px-4 py-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Available to schedule</dt>
+            <dd className="mt-2 text-2xl font-semibold text-slate-100">
+              {stats ? formatCurrencyFromCents(stats.availableAmountCents, currency) : "—"}
+            </dd>
+          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-950/30 px-4 py-4">
+            <dt className="text-xs uppercase tracking-wide text-slate-500">Supporters</dt>
+            <dd className="mt-2 text-2xl font-semibold text-slate-100">
+              {stats ? stats.lifetimeDonationCount.toLocaleString() : "—"}
+            </dd>
+          </div>
+        </dl>
+        <section aria-label="Earnings trend" className="space-y-3">
+          <header className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-slate-200">Past activity</h3>
+            <span className="text-xs text-slate-500">Daily totals</span>
+          </header>
+          <ol className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            {trend.map((point) => (
+              <li
+                key={point.date}
+                className="rounded-2xl border border-slate-800 bg-slate-950/40 px-4 py-3 text-sm text-slate-200"
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-semibold">{formatDateLabel(point.date)}</span>
+                  <span className="text-xs text-slate-500">
+                    {formatCurrencyFromCents(point.amountCents, currency)}
+                  </span>
+                </div>
+                <div className="mt-3 h-2 rounded-full bg-slate-800">
+                  <span
+                    className="block h-2 rounded-full bg-emerald-400"
+                    style={{
+                      width: `${Math.min(100, point.amountCents / Math.max(1, stats?.availableAmountCents ?? 1) * 100)}%`
+                    }}
+                    role="presentation"
+                    aria-hidden="true"
+                  />
+                </div>
+              </li>
+            ))}
+            {trend.length === 0 && !isLoading ? (
+              <li className="rounded-2xl border border-dashed border-slate-800 bg-slate-950/40 px-4 py-6 text-center text-sm text-slate-500">
+                No donations recorded yet. Promote your challenge to start receiving support.
+              </li>
+            ) : null}
+          </ol>
+        </section>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/payouts/creator-payout-dashboard.tsx
+++ b/apps/web/src/components/payouts/creator-payout-dashboard.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  CreatorDonationConnection,
+  PayoutBatchConnection,
+  PayoutNotificationConnection
+} from "@trendpot/types";
+import {
+  creatorDonationsQueryOptions,
+  fetchCreatorDonations,
+  markPayoutNotificationsRead,
+  payoutBatchesQueryOptions,
+  payoutNotificationsQueryOptions
+} from "@/lib/payouts-queries";
+import { CreatorDonationsTable } from "./creator-donations-table";
+import { CreatorEarningsSummary } from "./creator-earnings-summary";
+import { PayoutBatchesCard } from "./payout-batches-card";
+import { PayoutNotificationCenter } from "./payout-notification-center";
+
+interface CreatorPayoutDashboardProps {
+  initialDonations?: CreatorDonationConnection;
+  initialBatches?: PayoutBatchConnection;
+  initialNotifications?: PayoutNotificationConnection;
+}
+
+export function CreatorPayoutDashboard({
+  initialDonations,
+  initialBatches,
+  initialNotifications
+}: CreatorPayoutDashboardProps) {
+  const queryClient = useQueryClient();
+  const donationOptions = useMemo(() => creatorDonationsQueryOptions({ first: 20 }), []);
+  const batchOptions = useMemo(() => payoutBatchesQueryOptions({ first: 6 }), []);
+  const notificationOptions = useMemo(() => payoutNotificationsQueryOptions({ first: 10 }), []);
+
+  const donationsQuery = useQuery({ ...donationOptions, initialData: initialDonations });
+  const batchesQuery = useQuery({ ...batchOptions, initialData: initialBatches });
+  const notificationsQuery = useQuery({ ...notificationOptions, initialData: initialNotifications });
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+
+  const markNotifications = useMutation({
+    mutationFn: markPayoutNotificationsRead,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: notificationOptions.queryKey });
+    }
+  });
+
+  const handleLoadMoreDonations = async () => {
+    if (!donationsQuery.data?.pageInfo.hasNextPage || !donationsQuery.data.pageInfo.endCursor) {
+      return;
+    }
+
+    setIsFetchingMore(true);
+    try {
+      const next = await fetchCreatorDonations({
+        first: 20,
+        after: donationsQuery.data.pageInfo.endCursor
+      });
+
+      queryClient.setQueryData<CreatorDonationConnection | undefined>(donationOptions.queryKey, (current) => {
+        if (!current) {
+          return next;
+        }
+
+        return {
+          ...next,
+          edges: [...current.edges, ...next.edges],
+          stats: next.stats,
+          trend: next.trend,
+          pageInfo: next.pageInfo
+        };
+      });
+    } finally {
+      setIsFetchingMore(false);
+    }
+  };
+
+  const donationConnection = queryClient.getQueryData<CreatorDonationConnection>(donationOptions.queryKey);
+  const batchesConnection = batchesQuery.data;
+  const notificationConnection = notificationsQuery.data;
+
+  return (
+    <section className="flex flex-col gap-8" aria-label="Creator payouts dashboard">
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <CreatorEarningsSummary
+          connection={donationConnection ?? donationsQuery.data}
+          isLoading={donationsQuery.isLoading || donationsQuery.isFetching}
+          error={donationsQuery.isError ? (donationsQuery.error as Error).message : null}
+        />
+        <PayoutBatchesCard connection={batchesConnection} isLoading={batchesQuery.isFetching} />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <CreatorDonationsTable
+          connection={donationConnection ?? donationsQuery.data}
+          isLoading={donationsQuery.isFetching}
+          onLoadMore={handleLoadMoreDonations}
+          isFetchingMore={isFetchingMore}
+        />
+        <PayoutNotificationCenter
+          connection={notificationConnection}
+          isLoading={notificationsQuery.isFetching}
+          isMutating={markNotifications.isPending}
+          onMarkAsRead={async (ids) => {
+            await markNotifications.mutateAsync(ids);
+          }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/payouts/payout-batches-card.tsx
+++ b/apps/web/src/components/payouts/payout-batches-card.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Card, CardContent, CardHeader } from "@trendpot/ui";
+import type { PayoutBatchConnection } from "@trendpot/types";
+import { formatCurrencyFromCents } from "@/lib/money";
+
+interface PayoutBatchesCardProps {
+  connection: PayoutBatchConnection | undefined;
+  isLoading: boolean;
+}
+
+const describeStatus = (status: string) => {
+  switch (status) {
+    case "scheduled":
+      return "Scheduled";
+    case "processing":
+      return "Processing";
+    case "paid":
+      return "Paid";
+    case "failed":
+      return "Needs attention";
+    default:
+      return status;
+  }
+};
+
+export function PayoutBatchesCard({ connection, isLoading }: PayoutBatchesCardProps) {
+  const batches = connection?.edges ?? [];
+  const currency = batches[0]?.node.currency ?? "KES";
+
+  return (
+    <Card aria-busy={isLoading} className="flex flex-col overflow-hidden">
+      <CardHeader className="gap-2">
+        <h2 className="text-lg font-semibold text-slate-100">Upcoming payouts</h2>
+        <p className="text-sm text-slate-400">
+          Your next disbursements and their processing status.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <ul className="flex flex-col divide-y divide-slate-800" aria-live="polite">
+          {batches.slice(0, 4).map(({ node }) => {
+            const statusLabel = describeStatus(node.status);
+            const amount = formatCurrencyFromCents(node.netAmountCents, node.currency ?? currency);
+            const scheduledDate = new Date(node.scheduledFor).toLocaleString();
+
+            return (
+              <li key={node.id} className="py-4 first:pt-0 last:pb-0">
+                <article className="flex flex-col gap-2" aria-label={`Payout ${statusLabel}`}>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h3 className="text-base font-semibold text-slate-100">{amount}</h3>
+                    <span
+                      className="rounded-full border border-emerald-400/50 px-3 py-1 text-xs font-medium uppercase tracking-wide text-emerald-300"
+                      aria-label={`Status: ${statusLabel}`}
+                    >
+                      {statusLabel}
+                    </span>
+                  </div>
+                  <dl className="grid grid-cols-1 gap-2 text-sm text-slate-400 sm:grid-cols-3">
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">Scheduled for</dt>
+                      <dd className="mt-1 text-slate-200">{scheduledDate}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">Donations</dt>
+                      <dd className="mt-1 text-slate-200">{node.donationCount.toLocaleString()}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">Gross amount</dt>
+                      <dd className="mt-1 text-slate-200">
+                        {formatCurrencyFromCents(node.totalAmountCents, node.currency ?? currency)}
+                      </dd>
+                    </div>
+                  </dl>
+                  {node.failureReason ? (
+                    <p className="rounded-xl bg-rose-900/40 px-4 py-3 text-xs text-rose-200" role="status">
+                      {node.failureReason}
+                    </p>
+                  ) : null}
+                </article>
+              </li>
+            );
+          })}
+          {batches.length === 0 && !isLoading ? (
+            <li className="py-6 text-sm text-slate-500">
+              No payouts are scheduled yet. Eligible donations will appear here once batched.
+            </li>
+          ) : null}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/payouts/payout-components.test.tsx
+++ b/apps/web/src/components/payouts/payout-components.test.tsx
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { CreatorDonationConnection, PayoutNotificationConnection } from "@trendpot/types";
+import { CreatorEarningsSummary } from "./creator-earnings-summary";
+import { PayoutNotificationCenter } from "./payout-notification-center";
+
+const sampleDonationConnection: CreatorDonationConnection = {
+  edges: [
+    {
+      cursor: "1",
+      node: {
+        id: "1",
+        status: "succeeded",
+        payoutState: "scheduled",
+        amountCents: 50000,
+        netAmountCents: 45000,
+        currency: "KES",
+        donatedAt: new Date("2024-05-01T12:00:00Z").toISOString(),
+        availableAt: null,
+        supporterName: "Ada",
+        challengeTitle: "May fundraiser",
+        payoutBatchId: "batch-1"
+      }
+    }
+  ],
+  pageInfo: { endCursor: "1", hasNextPage: false },
+  stats: {
+    lifetimeAmountCents: 50000,
+    lifetimeDonationCount: 1,
+    pendingAmountCents: 0,
+    availableAmountCents: 45000
+  },
+  trend: [
+    { date: new Date("2024-04-30T00:00:00Z").toISOString(), amountCents: 0 },
+    { date: new Date("2024-05-01T00:00:00Z").toISOString(), amountCents: 50000 }
+  ]
+};
+
+const sampleNotifications: PayoutNotificationConnection = {
+  edges: [
+    {
+      cursor: "n1",
+      node: {
+        id: "n1",
+        type: "payout.scheduled",
+        message: "KES 450 scheduled for Friday",
+        createdAt: new Date("2024-05-02T10:00:00Z").toISOString(),
+        eventAt: new Date("2024-05-02T10:00:00Z").toISOString(),
+        readAt: null,
+        metadata: {
+          payoutBatchId: "batch-1",
+          amountCents: 45000,
+          currency: "KES"
+        }
+      }
+    }
+  ],
+  pageInfo: { endCursor: "n1", hasNextPage: false }
+};
+
+test("CreatorEarningsSummary highlights total earnings", () => {
+  const markup = renderToStaticMarkup(
+    <CreatorEarningsSummary connection={sampleDonationConnection} isLoading={false} />
+  );
+
+  assert(markup.includes("Earnings overview"));
+  assert(markup.includes("Lifetime earnings"));
+  assert(markup.includes("KES"));
+});
+
+test("Notification center renders mark all control", () => {
+  const markup = renderToStaticMarkup(
+    <PayoutNotificationCenter connection={sampleNotifications} isLoading={false} />
+  );
+
+  assert(markup.includes("Mark all read"));
+  assert(markup.includes("Payout alerts"));
+});

--- a/apps/web/src/components/payouts/payout-notification-center.tsx
+++ b/apps/web/src/components/payouts/payout-notification-center.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button, Card, CardContent, CardHeader } from "@trendpot/ui";
+import type { PayoutNotificationConnection } from "@trendpot/types";
+
+interface PayoutNotificationCenterProps {
+  connection: PayoutNotificationConnection | undefined;
+  isLoading: boolean;
+  onMarkAsRead?: (ids: string[]) => Promise<void> | void;
+  isMutating?: boolean;
+}
+
+export function PayoutNotificationCenter({
+  connection,
+  isLoading,
+  onMarkAsRead,
+  isMutating,
+}: PayoutNotificationCenterProps) {
+  const edges = connection?.edges ?? [];
+  const unreadIds = useMemo(
+    () => edges.filter((edge) => !edge.node.readAt).map((edge) => edge.node.id),
+    [edges]
+  );
+  const seenIds = useRef(new Set<string>());
+  const [activeToasts, setActiveToasts] = useState<string[]>([]);
+
+  useEffect(() => {
+    const newUnread = edges.filter((edge) => !edge.node.readAt && !seenIds.current.has(edge.node.id));
+
+    if (newUnread.length === 0) {
+      return;
+    }
+
+    newUnread.forEach((edge) => {
+      seenIds.current.add(edge.node.id);
+      setActiveToasts((current) => Array.from(new Set([...current, edge.node.id])));
+      setTimeout(() => {
+        setActiveToasts((current) => current.filter((id) => id !== edge.node.id));
+      }, 6000);
+    });
+  }, [edges]);
+
+  const handleMarkAll = async () => {
+    if (!onMarkAsRead || unreadIds.length === 0) {
+      return;
+    }
+
+    await onMarkAsRead(unreadIds);
+  };
+
+  return (
+    <Card aria-busy={isLoading} className="relative flex flex-col overflow-hidden">
+      <div className="pointer-events-none absolute inset-x-4 top-4 z-10 flex flex-col gap-2" aria-live="assertive">
+        {activeToasts.map((id) => {
+          const notification = edges.find((edge) => edge.node.id === id)?.node;
+          if (!notification) {
+            return null;
+          }
+
+          return (
+            <div
+              key={id}
+              className="pointer-events-auto rounded-2xl border border-emerald-500/40 bg-emerald-950/80 px-4 py-3 text-sm text-emerald-100 shadow-lg shadow-emerald-900/40"
+              role="status"
+            >
+              <p className="font-medium">{notification.message}</p>
+              <p className="text-xs text-emerald-300">{new Date(notification.eventAt).toLocaleString()}</p>
+            </div>
+          );
+        })}
+      </div>
+      <CardHeader className="gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Payout alerts</h2>
+            <p className="text-sm text-slate-400">Stay on top of payout lifecycle updates.</p>
+          </div>
+          <Button
+            variant="secondary"
+            disabled={!unreadIds.length || isMutating}
+            onClick={handleMarkAll}
+            aria-live="polite"
+          >
+            {isMutating ? "Marking…" : `Mark all read (${unreadIds.length})`}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4" aria-live="polite">
+        {edges.length === 0 && !isLoading ? (
+          <p className="rounded-2xl border border-dashed border-slate-800 bg-slate-950/40 px-4 py-6 text-sm text-slate-500">
+            You are all caught up. New payout updates will appear here and as toasts.
+          </p>
+        ) : null}
+        <ul className="space-y-3">
+          {edges.slice(0, 6).map(({ node }) => (
+            <li key={node.id} className="rounded-2xl border border-slate-800 bg-slate-950/40 px-4 py-4">
+              <article>
+                <header className="flex items-center justify-between gap-3">
+                  <h3 className="text-sm font-semibold text-slate-100">{node.message}</h3>
+                  {node.readAt ? (
+                    <span className="text-xs text-slate-500">Read</span>
+                  ) : (
+                    <span className="text-xs text-emerald-300">New</span>
+                  )}
+                </header>
+                <p className="mt-2 text-xs text-slate-500">{new Date(node.eventAt).toLocaleString()}</p>
+                {node.metadata ? (
+                  <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-400">
+                    {node.metadata.amountCents ? (
+                      <div>
+                        <dt>Amount</dt>
+                        <dd>
+                          {Intl.NumberFormat("en-KE", {
+                            style: "currency",
+                            currency: node.metadata.currency ?? "KES",
+                            maximumFractionDigits: 0
+                          }).format((node.metadata.amountCents ?? 0) / 100)}
+                        </dd>
+                      </div>
+                    ) : null}
+                    {node.metadata.payoutBatchId ? (
+                      <div>
+                        <dt>Batch</dt>
+                        <dd>{node.metadata.payoutBatchId}</dd>
+                      </div>
+                    ) : null}
+                    {node.metadata.donationId ? (
+                      <div>
+                        <dt>Donation</dt>
+                        <dd>{node.metadata.donationId}</dd>
+                      </div>
+                    ) : null}
+                  </dl>
+                ) : null}
+              </article>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/payouts-queries.test.ts
+++ b/apps/web/src/lib/payouts-queries.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { CreatorDonationConnection } from "@trendpot/types";
+import { GraphQLRequestError, apiClient } from "./api-client";
+import {
+  creatorDonationsQueryOptions,
+  fetchCreatorDonations,
+  markPayoutNotificationsRead,
+  payoutNotificationsQueryOptions
+} from "./payouts-queries";
+
+const sampleDonations: CreatorDonationConnection = {
+  edges: [],
+  pageInfo: { endCursor: null, hasNextPage: false },
+  stats: {
+    lifetimeAmountCents: 0,
+    lifetimeDonationCount: 0,
+    pendingAmountCents: 0,
+    availableAmountCents: 0
+  },
+  trend: []
+};
+
+test("fetchCreatorDonations forwards params to the API client", async () => {
+  const original = apiClient.getCreatorDonations;
+  apiClient.getCreatorDonations = (async (params) => {
+    assert.deepEqual(params, { first: 5 });
+    return sampleDonations;
+  }) as typeof original;
+
+  const result = await fetchCreatorDonations({ first: 5 });
+  assert.equal(result, sampleDonations);
+
+  apiClient.getCreatorDonations = original;
+});
+
+test("creatorDonationsQueryOptions provides a stable query key", () => {
+  const options = creatorDonationsQueryOptions({ first: 10 });
+  assert.deepEqual(options.queryKey, ["payouts", "creator", "donations", { first: 10 }]);
+});
+
+test("markPayoutNotificationsRead wraps GraphQL errors", async () => {
+  const original = apiClient.markPayoutNotificationsRead;
+  apiClient.markPayoutNotificationsRead = (async () => {
+    throw new GraphQLRequestError([{ message: "Failure" }]);
+  }) as typeof original;
+
+  await assert.rejects(() => markPayoutNotificationsRead(["1"]), /Failure/);
+
+  apiClient.markPayoutNotificationsRead = original;
+});
+
+test("notification query options configure polling", () => {
+  const options = payoutNotificationsQueryOptions({ first: 3 });
+  assert.equal(options.refetchInterval, 1000 * 30);
+  assert.deepEqual(options.queryKey, ["payouts", "creator", "notifications", { first: 3 }]);
+});

--- a/apps/web/src/lib/payouts-queries.ts
+++ b/apps/web/src/lib/payouts-queries.ts
@@ -1,0 +1,71 @@
+import type {
+  CreatorDonationConnection,
+  CreatorDonationsRequest,
+  PayoutBatchConnection,
+  PayoutBatchesRequest,
+  PayoutNotificationConnection,
+  PayoutNotificationsRequest,
+  GraphQLOperationOptions
+} from "@trendpot/types";
+import { GraphQLRequestError, apiClient } from "./api-client";
+
+export const creatorDonationsQueryKey = (params: CreatorDonationsRequest = {}) =>
+  ["payouts", "creator", "donations", params] as const;
+
+export const fetchCreatorDonations = async (
+  params: CreatorDonationsRequest = {},
+  options: GraphQLOperationOptions = {}
+): Promise<CreatorDonationConnection> => {
+  return apiClient.getCreatorDonations(params, options);
+};
+
+export const creatorDonationsQueryOptions = (params: CreatorDonationsRequest = {}) => ({
+  queryKey: creatorDonationsQueryKey(params),
+  queryFn: () => fetchCreatorDonations(params),
+  staleTime: 1000 * 30
+});
+
+export const payoutBatchesQueryKey = (params: PayoutBatchesRequest = {}) =>
+  ["payouts", "creator", "batches", params] as const;
+
+export const fetchPayoutBatches = async (
+  params: PayoutBatchesRequest = {},
+  options: GraphQLOperationOptions = {}
+): Promise<PayoutBatchConnection> => {
+  return apiClient.getPayoutBatches(params, options);
+};
+
+export const payoutBatchesQueryOptions = (params: PayoutBatchesRequest = {}) => ({
+  queryKey: payoutBatchesQueryKey(params),
+  queryFn: () => fetchPayoutBatches(params),
+  staleTime: 1000 * 30
+});
+
+export const payoutNotificationsQueryKey = (params: PayoutNotificationsRequest = {}) =>
+  ["payouts", "creator", "notifications", params] as const;
+
+export const fetchPayoutNotifications = async (
+  params: PayoutNotificationsRequest = {},
+  options: GraphQLOperationOptions = {}
+): Promise<PayoutNotificationConnection> => {
+  return apiClient.getPayoutNotificationFeed(params, options);
+};
+
+export const payoutNotificationsQueryOptions = (params: PayoutNotificationsRequest = {}) => ({
+  queryKey: payoutNotificationsQueryKey(params),
+  queryFn: () => fetchPayoutNotifications(params),
+  refetchInterval: 1000 * 30,
+  staleTime: 1000 * 15
+});
+
+export const markPayoutNotificationsRead = async (ids: string[]): Promise<number> => {
+  try {
+    return await apiClient.markPayoutNotificationsRead(ids);
+  } catch (error) {
+    if (error instanceof GraphQLRequestError && error.messages.length > 0) {
+      throw new Error(error.messages[0]);
+    }
+
+    throw error;
+  }
+};

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -13,6 +13,6 @@
       "@trendpot/types": ["../../packages/types/src"]
     }
   },
-  "include": ["src/lib/**/*.ts", "src/**/*.test.ts"],
+  "include": ["src/lib/**/*.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
   "exclude": ["dist-tests"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "7.5.0",
     "@typescript-eslint/parser": "7.5.0",
+    "@types/node": "20.12.7",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "prettier": "3.2.5",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,3 +3,4 @@ export * from "./leaderboard";
 export * from "./graphql-client";
 export * from "./auth";
 export * from "./tiktok";
+export * from "./payouts";

--- a/packages/types/src/payouts.ts
+++ b/packages/types/src/payouts.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+export const donationStatusSchema = z.enum(["pending", "succeeded", "refunded", "failed"]);
+export type DonationStatus = z.infer<typeof donationStatusSchema>;
+
+export const donationPayoutStateSchema = z.enum([
+  "unassigned",
+  "scheduled",
+  "processing",
+  "paid",
+  "failed"
+]);
+export type DonationPayoutState = z.infer<typeof donationPayoutStateSchema>;
+
+export const creatorDonationSchema = z.object({
+  id: z.string(),
+  status: donationStatusSchema,
+  payoutState: donationPayoutStateSchema,
+  amountCents: z.number().int().nonnegative(),
+  netAmountCents: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  donatedAt: z.string(),
+  availableAt: z.string().nullable(),
+  supporterName: z.string().nullable(),
+  challengeTitle: z.string().nullable(),
+  payoutBatchId: z.string().nullable()
+});
+export type CreatorDonation = z.infer<typeof creatorDonationSchema>;
+
+export const creatorDonationEdgeSchema = z.object({
+  cursor: z.string(),
+  node: creatorDonationSchema
+});
+
+export const creatorDonationStatsSchema = z.object({
+  lifetimeAmountCents: z.number().int().nonnegative(),
+  lifetimeDonationCount: z.number().int().nonnegative(),
+  pendingAmountCents: z.number().int().nonnegative(),
+  availableAmountCents: z.number().int().nonnegative()
+});
+
+export const creatorDonationTrendPointSchema = z.object({
+  date: z.string(),
+  amountCents: z.number().int().nonnegative()
+});
+
+export const connectionPageInfoSchema = z.object({
+  endCursor: z.string().nullable(),
+  hasNextPage: z.boolean()
+});
+
+export const creatorDonationConnectionSchema = z.object({
+  edges: z.array(creatorDonationEdgeSchema),
+  pageInfo: connectionPageInfoSchema,
+  stats: creatorDonationStatsSchema,
+  trend: z.array(creatorDonationTrendPointSchema)
+});
+export type CreatorDonationConnection = z.infer<typeof creatorDonationConnectionSchema>;
+
+export const payoutBatchStatusSchema = z.enum(["scheduled", "processing", "paid", "failed"]);
+export type PayoutBatchStatus = z.infer<typeof payoutBatchStatusSchema>;
+
+export const payoutBatchSchema = z.object({
+  id: z.string(),
+  status: payoutBatchStatusSchema,
+  scheduledFor: z.string(),
+  completedAt: z.string().nullable(),
+  startedAt: z.string().nullable(),
+  donationCount: z.number().int().nonnegative(),
+  totalAmountCents: z.number().int().nonnegative(),
+  netAmountCents: z.number().int().nonnegative(),
+  currency: z.string().length(3),
+  periodStart: z.string().nullable(),
+  periodEnd: z.string().nullable(),
+  failureReason: z.string().nullable()
+});
+export type PayoutBatch = z.infer<typeof payoutBatchSchema>;
+
+export const payoutBatchEdgeSchema = z.object({
+  cursor: z.string(),
+  node: payoutBatchSchema
+});
+
+export const payoutBatchConnectionSchema = z.object({
+  edges: z.array(payoutBatchEdgeSchema),
+  pageInfo: connectionPageInfoSchema
+});
+export type PayoutBatchConnection = z.infer<typeof payoutBatchConnectionSchema>;
+
+export const payoutNotificationTypeSchema = z.enum([
+  "donation.cleared",
+  "payout.scheduled",
+  "payout.processing",
+  "payout.paid",
+  "payout.failed"
+]);
+export type PayoutNotificationType = z.infer<typeof payoutNotificationTypeSchema>;
+
+export const payoutNotificationMetadataSchema = z
+  .object({
+    donationId: z.string().optional(),
+    payoutBatchId: z.string().optional(),
+    amountCents: z.number().int().nonnegative().optional(),
+    currency: z.string().length(3).optional()
+  })
+  .nullable();
+
+export const payoutNotificationSchema = z.object({
+  id: z.string(),
+  type: payoutNotificationTypeSchema,
+  message: z.string(),
+  createdAt: z.string(),
+  eventAt: z.string(),
+  readAt: z.string().nullable(),
+  metadata: payoutNotificationMetadataSchema
+});
+export type PayoutNotification = z.infer<typeof payoutNotificationSchema>;
+
+export const payoutNotificationEdgeSchema = z.object({
+  cursor: z.string(),
+  node: payoutNotificationSchema
+});
+
+export const payoutNotificationConnectionSchema = z.object({
+  edges: z.array(payoutNotificationEdgeSchema),
+  pageInfo: connectionPageInfoSchema
+});
+export type PayoutNotificationConnection = z.infer<typeof payoutNotificationConnectionSchema>;

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -4,7 +4,9 @@
     "declaration": true,
     "declarationDir": "dist",
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "module": "NodeNext",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules"]

--- a/test-shims/@trendpot/ui/index.js
+++ b/test-shims/@trendpot/ui/index.js
@@ -1,7 +1,13 @@
 const React = require("../../react");
 
-const Button = ({ children, ...props }) => {
-  return { type: "button", props: { ...props, children } };
-};
+const createElement = (type) => ({ children, ...props }) => ({
+  type,
+  props: { ...props, children }
+});
 
-module.exports = { Button };
+const Button = createElement("button");
+const Card = createElement("div");
+const CardContent = createElement("div");
+const CardHeader = createElement("div");
+
+module.exports = { Button, Card, CardContent, CardHeader };

--- a/test-shims/react-dom/server/index.js
+++ b/test-shims/react-dom/server/index.js
@@ -34,8 +34,5 @@ const renderNode = (node) => {
   return `${openTag}${children}</${node.type}>`;
 };
 
-module.exports = {
-  renderToString(element) {
-    return renderNode(element);
-  }
-};
+exports.renderToString = (element) => renderNode(element);
+exports.renderToStaticMarkup = (element) => renderNode(element);

--- a/test-shims/ts-loader.mjs
+++ b/test-shims/ts-loader.mjs
@@ -24,6 +24,8 @@ const shimMap = new Map([
   ["@trendpot/ui", new URL("@trendpot/ui/index.js", shimBase).href]
 ]);
 
+const repoRoot = new URL("../", shimBase);
+
 /**
  * Minimal loader that transpiles TypeScript on the fly so we can run the Node
  * test runner without pulling additional tooling.
@@ -41,6 +43,18 @@ export async function resolve(specifier, context, defaultResolve) {
         const tsUrl = new URL(`${specifier}.ts`, parentUrl);
         return { url: tsUrl.href, shortCircuit: true };
       }
+    }
+  }
+
+  if (specifier.startsWith("@/")) {
+    const basePath = new URL(`apps/web/src/${specifier.slice(2)}`, repoRoot);
+    const tsxUrl = new URL(`${basePath.href}.tsx`);
+    try {
+      await access(tsxUrl);
+      return { url: tsxUrl.href, shortCircuit: true };
+    } catch {
+      const tsUrl = new URL(`${basePath.href}.ts`);
+      return { url: tsUrl.href, shortCircuit: true };
     }
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated payouts module on the API with donation, batch, and notification schemas plus guarded GraphQL resolvers
- extend the shared GraphQL client/types for creator payout connections and notification helpers
- build a `/me/payouts` dashboard with responsive payout widgets, polling notification center, and associated unit tests
- update test shims to resolve UI aliases for new component coverage

## Testing
- pnpm --filter api test
- node --loader ../../test-shims/ts-loader.mjs --test src/lib/payouts-queries.test.ts
- node --loader ../../test-shims/ts-loader.mjs --test src/components/payouts/payout-components.test.tsx
- node --loader ../../test-shims/ts-loader.mjs --test src/lib/money.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d9460b1a38832e919680fe73992c7e