### PR TITLE
Fix Daraja STK push logging block

### DIFF
--- a/apps/api/src/mpesa/daraja.client.ts
+++ b/apps/api/src/mpesa/daraja.client.ts
@@ -149,10 +149,6 @@ export class DarajaClient {
 
     requestLogger.log("Dispatching Daraja STK push", metadata);
     requestLogger.info({ event: "daraja.stkpush.start", ...metadata });
-      requestId: request.requestId,
-      amount: request.amount,
-      shortCode: this.shortCode
-    });
 
     const timestamp = formatTimestamp(new Date());
     const password = Buffer.from(`${this.shortCode}${this.passkey}${timestamp}`).toString("base64");


### PR DESCRIPTION
## Summary
- remove the stray metadata block following the daraja.stkpush.start log in the STK push client so the method contains only valid statements

## Testing
- pnpm -w run lint *(fails: web lint step cannot find `next` binary in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9c159f88832eba65af95a574f233