### PR TITLE
Refactor donation service and schema

### DIFF
--- a/apps/api/src/donations/donation.service.test.ts
+++ b/apps/api/src/donations/donation.service.test.ts
@@ -7,7 +7,7 @@ import type { SignatureVerificationResult } from "../webhooks/mpesa-signature.se
 interface DonationRecord {
   _id: string;
   mpesaCheckoutRequestId: string;
-  merchantRequestId?: string;
+  mpesaMerchantRequestId?: string;
   accountReference?: string;
   amountCents: number;
   mpesaReceipt?: string;
@@ -41,7 +41,7 @@ class DonationModelStub {
       const record: DonationRecord = {
         _id: String(this.sequence++),
         mpesaCheckoutRequestId: input.mpesaCheckoutRequestId ?? "",
-        merchantRequestId: input.merchantRequestId,
+        mpesaMerchantRequestId: input.mpesaMerchantRequestId,
         amountCents: input.amountCents ?? 0,
         mpesaReceipt: input.mpesaReceipt,
         payerPhone: input.payerPhone,
@@ -77,7 +77,7 @@ class DonationModelStub {
         match.mpesaReceipt = patched.mpesaReceipt;
         match.payerPhone = patched.payerPhone;
         match.transactionCompletedAt = patched.transactionCompletedAt;
-        match.merchantRequestId = patched.merchantRequestId;
+        match.mpesaMerchantRequestId = patched.mpesaMerchantRequestId;
         match.accountReference = patched.accountReference;
         match.status = patched.status;
         match.resultCode = patched.resultCode;
@@ -156,8 +156,16 @@ const verification: SignatureVerificationResult = { valid: true };
 
 const connection = new ConnectionStub();
 
+class DarajaClientStub {
+  async requestStkPush() {
+    throw new Error("Not implemented");
+  }
+}
+
+const daraja = new DarajaClientStub();
+
 const buildService = (model: DonationModelStub, audit: AuditLogServiceStub) =>
-  new DonationService(connection as never, model as never, audit as never);
+  new DonationService(connection as never, model as never, audit as never, daraja as never);
 
 test("DonationService processes new callbacks and records audit entries", async () => {
   const model = new DonationModelStub();

--- a/apps/api/src/donations/donations.module.ts
+++ b/apps/api/src/donations/donations.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 import { DarajaClient } from "../mpesa/daraja.client";
+import { AuditLogService } from "../audit/audit-log.service";
 import { DonationResolver } from "./donation.resolver";
 import { DonationService } from "./donation.service";
 import { DonationEntity, DonationSchema } from "./donation.schema";
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: DonationEntity.name, schema: DonationSchema }])],
-  providers: [DonationService, DonationResolver, DarajaClient],
+  providers: [DonationService, DonationResolver, DarajaClient, AuditLogService],
   exports: [DonationService]
 })
 export class DonationsModule {}


### PR DESCRIPTION
## Summary
- merge the duplicated donation service implementations into a single class with unified dependencies
- expand the donation schema and module wiring to support the consolidated service behaviour and helper exports
- update the donation unit tests to reflect the new constructor signature and field names

## Testing
- pnpm -w run lint *(fails: apps/web lint requires the Next.js binary in this environment)*
- NODE_PATH=../../test-shims node --loader ../../test-shims/ts-loader.mjs --test src/donations/donation.service.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68dd9bf4b4d8832e96c0777c26ff11e1